### PR TITLE
Member pages and links to them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 home/secret-key.txt
 home/db/*.db
 home/import/*
-
+*~

--- a/biostar/server/views.py
+++ b/biostar/server/views.py
@@ -14,6 +14,11 @@ def index(request):
 
     return html.template( request, name='index.html', questions=questions)
 
+def member(request, uid):
+    "Member's profile page"
+    member = models.User.objects.get(id=uid)
+    return html.template(request, name='member.html', member=member)
+
 def question(request, pid):
     "Returns a question with all answers"
     question = models.Question.objects.get(id=pid)

--- a/biostar/urls.py
+++ b/biostar/urls.py
@@ -15,6 +15,7 @@ urlpatterns = patterns('',
     ('^newquestion/$', direct_to_template, {'template': 'new.question.html'}),
 
 
+    (r'^member/(?P<uid>\d+)/$', 'biostar.server.views.member'),
     (r'^question/(?P<pid>\d+)/$', 'biostar.server.views.question'),
     (r'^newpost/$', 'biostar.server.views.newpost'),
     

--- a/home/static/biostar.css
+++ b/home/static/biostar.css
@@ -166,3 +166,9 @@ a:hover, a.question-title {
     background-image: url("/static/img/vote/vote-down-on.png");
 }
 
+.user-link {
+  color: #8F2C47;
+  font-weight: bold;
+  font-size: 115%;
+  text-decoration: none;
+}

--- a/home/templates/base.html
+++ b/home/templates/base.html
@@ -45,7 +45,10 @@
             <form id="search2" action="/search" method="get">
             <div style="float:right">
             {%if user.is_authenticated %}
-                  <b>{{user.get_full_name}}</b> <b>100</b> &bull; <a href="/logout/?next_page=/">logout</a> &bull; tools
+                <b><a href="/member/{{user.id}}">{{user.get_full_name}}</a
+                ></b> <b>100</b
+                > &bull; <a href="/logout/?next_page=/">logout</a
+                > &bull; <a>tools</a>
             {% else %}
                 <span class="note">First time here? Check out the FAQ.</a> &bull; <a href="/openid/login/">login</a>
             {% endif %}
@@ -68,7 +71,7 @@
                 </td>
                 <td class="nav" valign="bottom">
                     <a href="/">Questions</a> <a href="#">Tags</a>
-                    <a href="/">Users</a> 
+                    <a href="/">Members</a> 
                     <a href="/">Badges</a> 
                     <a href="/">Unanswered</a></li>
                 </td>

--- a/home/templates/index.html
+++ b/home/templates/index.html
@@ -32,10 +32,14 @@
                     <a class="post-tag">tag</a>
                     <a class="post-tag">another</a>
                 </div>
-            
+
                 <div class="started right">
                     <span class="relativetime">1h ago</span>
-                    by <a class="user-link">{{q.post.author.username}}</a>
+                    by 
+                    <a class="user-link" href="/member/{{q.post.author.id}}">
+                      <span>{{q.post.author.first_name}}</span>
+                      <span>{{q.post.author.last_name}}</span>
+                    </a>
                     <span class="reputation-score">0</span>
                 </div>
             </td>

--- a/home/templates/member.html
+++ b/home/templates/member.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+
+{% block subheader %}
+  <h2>{{ member.first_name }} {{ member.last_name }}</h2>
+{% endblock %}
+
+{% block mainbody %}
+<div>Joined {{ member.date_joined|timesince }} ago</div>
+{% endblock %}

--- a/home/templates/question.html
+++ b/home/templates/question.html
@@ -53,7 +53,12 @@
                         mod | edit | flag
                     </div>
                     <div class="right">
-                        Author: {{ params.question.post.author.username }}
+                        Author: 
+                         <a class="user-link" 
+                         href="/member/{{params.question.post.author.id}}">
+                          {{params.question.post.author.first_name}}
+                          {{params.question.post.author.last_name}}
+                         </a>
                     </div>
                 </td>
             </tr>
@@ -77,7 +82,11 @@
                         mod | edit | flag
                     </div>
                     <div class="right">
-                        Author: {{ answer.post.author.username }}
+                        Author: <a class="user-link" 
+                         href="/member/{{answer.post.author.id}}">
+                          {{answer.post.author.first_name}}
+                          {{answer.post.author.last_name}}
+                         </a>
                     </div>
                 </td>
             </tr>


### PR DESCRIPTION
The page only shows the names and how long ago the member joined.
Calling our community members "users" seems a bit less respectful than
"Members" so I made the url /member/&lt;id&gt;
