### PR TITLE
Website revision (git's sha1 commit) in the footer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
+*~
 home/secret-key.txt
 home/db/*.db
 home/import/*
-*~
+home/templates/website.revision.html

--- a/biostar.sh
+++ b/biostar.sh
@@ -30,6 +30,19 @@ echo "*** BIOSTAR_HOME=$BIOSTAR_HOME"
 echo "*** BIOSTAR_HOSTNAME=$BIOSTAR_HOSTNAME"
 echo "*** DJANGO_SETTINGS_MODULE=$DJANGO_SETTINGS_MODULE"
 
+# Import current commit SHA1 into a template to display on all web pages
+target_rev_file="$BIOSTAR_HOME/templates/website.revision.html"
+
+tail -n 1 $BIOSTAR_SRC/.git/logs/HEAD  | \
+  awk '{print $2}' | \
+  awk '/^[0-9a-f]+$/ \
+      {print "<a href=\"https://github.com/ialbert/biostar-central/commit/" \
+      $1 "\">" substr($1,1,5) "</a>"}' > $target_rev_file
+
+if [ ${PIPESTATUS[0]} -ne "0"  -o  ! -s $target_rev_file ]; then
+  echo -e "***\n*** WARNING: Failed to import revision info from .git\n***\n\n"
+fi
+
 if [ $# == 0 ]; then
 	echo ''
 	echo Usage:

--- a/home/templates/base.html
+++ b/home/templates/base.html
@@ -115,6 +115,7 @@
   
 <div id="footer">
     Powered by <a href="/"><img src="/static/biostar.antipixel.png" /></a> 
+    &bull; Revision {% include "website.revision.html" %}
     &bull; Copyright 2011 by <a href=".">BioStar team</a>
     {% if debug %}
       <br><a id="toggle-queries">{{sql_queries|length}} SQL queries</a>


### PR DESCRIPTION
I explored the different approaches:
1. Git hooks were not designed for that purpose and required too much code and hacking.
2. Reading .git from Django required pulling in too much of the filesystem functionality which would need to run on every page hit.

Putting the revision lookup into "biostar.sh" is the right place because that way it's the most convenient access to both worlds.

I also added a test and a warning if the lookup fails.

The lookup will be made on any biostar.sh action. You don't need to restart the server but you should at lest run the "./biostar.sh test" when deploying.
