### PR TITLE
Remove dangerous gitignore paths (libs, conf) and absolutize others

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,8 @@
 .DS_Store
 .idea/*
 biostar.db
-import/*
-main/db/*
+/import/*
+/main/db/*
 coverage.xml
-report/*
-conf/*
-apache/export/*
-libs/*
+/report/*
+/apache/export/*


### PR DESCRIPTION
The way this repo's .gitignore is configured, changes in `/libs` and `/conf` are silently ignored, which makes it easy to forget to check in changes that don't show up in `git status`. Also, I think some of the paths were meant to be absolute rather than relative patterns (leading slash). The way it was, the contents of any "libs" or "conf" directory within the repo were being ignored.
