### PR TITLE
Fix the grammar of the off-topic template.

### DIFF
--- a/biostar/server/templates/messages/offtopic_posts.html
+++ b/biostar/server/templates/messages/offtopic_posts.html
@@ -1,6 +1,6 @@
 <p>Hello {{ user.name }}!</p>
 
-<p>We believe that this post is does not fit the main topic of this site. </p>
+<p>We believe that this post does not fit the main topic of this site. </p>
 
 <p>{{ comment }}</p>
 


### PR DESCRIPTION
I've noticed that the post closing template has an extraneous "is" in it. This just removes it.
