### PR TITLE
Only display authorized post moderation actions

### DIFF
--- a/biostar3/forum/auth.py
+++ b/biostar3/forum/auth.py
@@ -85,13 +85,7 @@ def create_toplevel_post(data, user, file=None):
 
 
 def can_moderate_post(request, user, post):
-    if user.is_superuser:
-        return True
-
-    if user.is_staff or user.is_moderator:
-        return True
-
-    return False
+    return user.can_moderate_post(post)
 
 
 def can_moderate_user(request, user, target):

--- a/biostar3/forum/templates/post_moderate.html
+++ b/biostar3/forum/templates/post_moderate.html
@@ -12,10 +12,7 @@
                     written by <b>{{post.author.name}}</b>
                 </div>
 
-                 <div align="center" style="padding-bottom:1ex">
-            Actions with <i class="fa fa-exclamation-triangle"></i> require moderator access.
-        </div>
-
+                {% if "delete" in moderation_actions %}
                 <div>
                     <input type="radio" name="action" value="delete"> Delete post.
                 </div>
@@ -24,8 +21,9 @@
                     <textarea class="u-full-width" type="text" size="50"
                               name="reason" placeholder="State the reason for deleting"></textarea>
                 </div>
+                {% endif %}
 
-
+                {% if "close" in moderation_actions %}
                 <div>
                     <input type="radio" name="action" value="close"> Close post.
                 </div>
@@ -34,7 +32,9 @@
                 <textarea class="u-full-width" type="text" size="50"
                           name="reason" placeholder="State the reason for closing"></textarea>
                 </div>
+                {% endif %}
 
+                {% if "duplicate" in moderation_actions %}
                 <div>
                     <input type="radio" name="action" value="close"> Close as duplicate.
                 </div>
@@ -43,28 +43,37 @@
                 <textarea class="u-full-width" type="text" size="50" name="reason"
                           placeholder="Enter urls to duplicates"></textarea>
                 </div>
+                {% endif %}
 
+                {% if "restore" in moderation_actions %}
                 <div>
-                    <input type="radio" name="action" value="restore"> <i class="fa fa-exclamation-triangle"></i>  Restore deleted/closed post.
+                    <input type="radio" name="action" value="restore"> Restore deleted/closed post.
                 </div>
+                {% endif %}
 
-
+                {% if "move_to_answer" in moderation_actions %}
                 <div>
                     <input type="radio" name="action" value="move_to_answer"> Move to an answer.
                 </div>
+                {% endif %}
 
+                {% if "move_to_comment" in moderation_actions %}
                 <div>
                     <input type="radio" name="action" value="move_to_comment"> Move to a top level comment.
                 </div>
+                {% endif %}
 
+                {% if "reparent" in moderation_actions %}
                  <div>
                     <input type="radio" name="action" value="reparent"> Move to parent id: <input type="text" size="4" name="parent_id" style="height:1.5em" value="">
                 </div>
+                {% endif %}
 
+                {% if "move_to_question" in moderation_actions %}
                 <div>
                     <input type="radio" name="action" value="move_to_question"> Move to a new question. Tags: <input type="text" name="tags" style="height:1.5em" value="">
                 </div>
-
+                {% endif %}
 
                 <div class="row">
                     <div class="submit">

--- a/biostar3/forum/tests/test_moderation.py
+++ b/biostar3/forum/tests/test_moderation.py
@@ -1,0 +1,138 @@
+import logging
+
+from django.test import TestCase
+
+from faker import Factory
+
+from biostar3.forum import auth
+from biostar3.forum.models import User, Post
+
+logging.disable(logging.INFO)
+
+f = Factory.create()
+
+def create_post():
+    author = User.objects.create(name=f.name(), email=f.email())
+    auth.add_user_attributes(author)
+
+    post_data = dict(
+        title = f.sentence(),
+        content = f.text(),
+        tags = ""
+    )
+    post = auth.create_toplevel_post(user=author, data=post_data)
+
+    return author, post
+
+class ModerationTests(TestCase):
+    def test_user_cant_restore(self):
+        "A normal user can't restore a closed post"
+
+        normal_user = User.objects.create(name=f.name(), email=f.email())
+        auth.add_user_attributes(normal_user)
+
+        author, post = create_post()
+        post.status = Post.CLOSED
+        post.save()
+
+        self.assertFalse("restore" in post.moderation_actions(normal_user))
+
+    def test_author_cant_restore(self):
+        "The author can't restore a closed post"
+
+        author, post = create_post()
+        post.status = Post.CLOSED
+        post.save()
+
+        self.assertFalse("restore" in post.moderation_actions(author))
+
+    def test_moderator_can_restore(self):
+        "A moderator can restore a closed post"
+
+        moderator_user = User.objects.create(name=f.name(), email=f.email(), type=User.MODERATOR)
+        auth.add_user_attributes(moderator_user)
+
+        author, post = create_post()
+        post.status = Post.CLOSED
+        post.save()
+
+        self.assertTrue("restore" in post.moderation_actions(moderator_user))
+
+    def test_admin_can_restore(self):
+        "An admin can restore a closed post"
+
+        admin_user = User.objects.create(name=f.name(), email=f.email(), type=User.ADMIN)
+        auth.add_user_attributes(admin_user)
+
+        author, post = create_post()
+        post.status = Post.CLOSED
+        post.save()
+
+        self.assertTrue("restore" in post.moderation_actions(admin_user))
+
+    def test_can_close_top_level_post(self):
+        "Can close a top-level post"
+
+        moderator_user = User.objects.create(name=f.name(), email=f.email(), type=User.MODERATOR)
+        auth.add_user_attributes(moderator_user)
+
+        author, post = create_post()
+
+        self.assertTrue("close" in post.moderation_actions(moderator_user))
+
+    def test_cant_close_child_post(self):
+        "Can't close a child post"
+
+        moderator_user = User.objects.create(name=f.name(), email=f.email(), type=User.MODERATOR)
+        auth.add_user_attributes(moderator_user)
+
+        author, post = create_post()
+        reply = auth.create_content_post(user=author, parent=post, content=f.sentence())
+
+        self.assertFalse("close" in reply.moderation_actions(moderator_user))
+
+    def test_can_mark_duplicate_top_level_post(self):
+        "Can mark a top-level post as a duplicate"
+
+        moderator_user = User.objects.create(name=f.name(), email=f.email(), type=User.MODERATOR)
+        auth.add_user_attributes(moderator_user)
+
+        author, post = create_post()
+
+        self.assertTrue("duplicate" in post.moderation_actions(moderator_user))
+
+    def test_cant_mark_duplicate_child_post(self):
+        "Can't mark child posts as a duplicate"
+
+        moderator_user = User.objects.create(name=f.name(), email=f.email(), type=User.MODERATOR)
+        auth.add_user_attributes(moderator_user)
+
+        author, post = create_post()
+        reply = auth.create_content_post(user=author, parent=post, content=f.sentence())
+
+        self.assertFalse("duplicate" in reply.moderation_actions(moderator_user))
+
+    def test_cant_move_top_level_post(self):
+        "Can't move top-level posts to other post types"
+
+        moderator_user = User.objects.create(name=f.name(), email=f.email(), type=User.MODERATOR)
+        auth.add_user_attributes(moderator_user)
+
+        author, post = create_post()
+
+        self.assertFalse("move_to_answer" in post.moderation_actions(moderator_user))
+        self.assertFalse("move_to_comment" in post.moderation_actions(moderator_user))
+        self.assertFalse("move_to_question" in post.moderation_actions(moderator_user))
+
+    def test_can_move_child_post(self):
+        "Can move child posts to other post types"
+
+        moderator_user = User.objects.create(name=f.name(), email=f.email(), type=User.MODERATOR)
+        auth.add_user_attributes(moderator_user)
+
+        author, post = create_post()
+        reply = auth.create_content_post(user=author, parent=post, content=f.sentence())
+
+        self.assertTrue("move_to_answer" in reply.moderation_actions(moderator_user))
+        self.assertTrue("move_to_comment" in reply.moderation_actions(moderator_user))
+        self.assertTrue("move_to_question" in reply.moderation_actions(moderator_user))


### PR DESCRIPTION
Previously, all post moderation actions were displayed for all
posts. Users could be confused and select actions that are not
possible, and the UI needed to provide hints about restricted
actions.

Additionally, this commit refactors the logic for determining
authorized actions into the Post model. This makes it easier
to test this logic in isolation, and reduces the complexity of
view code.