### PR TITLE
Show individual post score for child posts

### DIFF
--- a/biostar3/forum/static/site.css
+++ b/biostar3/forum/static/site.css
@@ -40,6 +40,9 @@ Set up colors fo various widgets.
   background-color: #2c7990;
   color: white;
 }
+.box > .mark {
+  color: #2f5b14;
+}
 .error,
 .errorlist {
   color: #712d2d;

--- a/biostar3/forum/static/style.css
+++ b/biostar3/forum/static/style.css
@@ -36,6 +36,9 @@ Set up colors fo various widgets.
   background-color: #2c7990;
   color: white;
 }
+.box > .mark {
+  color: #2f5b14;
+}
 .error,
 .errorlist {
   color: #712d2d;

--- a/biostar3/forum/static/style.less
+++ b/biostar3/forum/static/style.less
@@ -29,6 +29,8 @@ This file is included in site.less.
 @ALERT_WARNING: #d9edf7;
 @ALERT_SUCCESS: #dff0d8;
 
+@MARK_COLOR: #2F5B14;
+
 /*
 Set up colors fo various widgets.
 */
@@ -70,6 +72,10 @@ Set up colors fo various widgets.
 .box.Tutorial {
   background-color: @TUTORIAL_COLOR;
   color: white;
+}
+
+.box > .mark {
+  color: @MARK_COLOR;
 }
 
 .error, .errorlist {

--- a/biostar3/forum/templates/post_list.html
+++ b/biostar3/forum/templates/post_list.html
@@ -19,13 +19,29 @@
                 <div class="row post_row">
 
                     <div class="box vote_count">
-                        <div class="c">{{ post.thread_score }}</div>
+                        <div class="c">
+                          {% if post.is_toplevel %}
+                            {{ post.thread_score }}
+                          {% else %}
+                            {{ post.vote_count }}
+                          {% endif %}
+                        </div>
                         <div class="t">votes</div>
                     </div>
 
                     <div class="box {{ post.subtype }}">
-                        <div class="c">{{ post.reply_count }}</div>
-                        <div class="t">answers</div>
+                        {% if post.is_toplevel %}
+                          <div class="c">
+                            {{ post.reply_count }}
+                          </div>
+                          <div class="t">answers</div>
+                        {% else %}
+                          {% if post.has_accepted %}
+                            <div class="c mark">
+                              <i class="fa fa-check-circle-o fa-2x"></i>
+                            </div>
+                          {% endif %}
+                        {% endif %}
                     </div>
 
                     <div class="box view_count lg">


### PR DESCRIPTION
Previously, child posts would show a score of 0, because
thread_score is only tracked for top-level posts. Now use
vote_count for child posts. Additionally, show whether a child
post was accepted rather than the number of answers, which is
meaningless for child posts.

This fixes https://github.com/ialbert/biostar-central/issues/305