### PR TITLE
Only display authorized user moderation actions

### DIFF
--- a/biostar3/forum/auth.py
+++ b/biostar3/forum/auth.py
@@ -94,16 +94,7 @@ def can_moderate_post(request, user, post):
 
 
 def can_moderate_user(request, user, target):
-    if target.is_staff:
-        return False
-
-    if target.is_admin:
-        return False
-
-    if user.is_staff or user.is_moderator:
-        return True
-
-    return False
+    return user.can_moderate_user(target)
 
 
 @transaction.atomic

--- a/biostar3/forum/templates/user_moderate.html
+++ b/biostar3/forum/templates/user_moderate.html
@@ -10,27 +10,30 @@
             Moderating user <b>{{ target.name }}</b>
         </div>
 
-        <div align="center" style="padding-bottom:1ex">
-            Actions with <i class="fa fa-exclamation-triangle"></i> require superuser access.
-        </div>
+        {% if "suspend" in moderation_actions %}
+          <div>
+              <input type="radio" name="action" value="suspend"> Suspend user.
+          </div>
+        {% endif %}
 
-        <div>
-            <input type="radio" name="action" value="suspend"> Suspend user.
-        </div>
+        {% if "reinstate" in moderation_actions %}
+          <div>
+              <input type="radio" name="action" value="reinstate"> Reinstate user.
+          </div>
+        {% endif %}
 
-        <div>
-            <input type="radio" name="action" value="reinstate"> Reinstate user.
-        </div>
+        {% if "ban" in moderation_actions %}
+          <div>
+              <input type="radio" name="action" value="ban"> Ban user.
+          </div>
+        {% endif %}
 
-        <div>
-            <input type="radio" name="action" value="ban"> <i class="fa fa-exclamation-triangle"></i> Ban user.
-        </div>
-
-        <div>
-            <input type="radio" name="action" value="merge">
-            <i class="fa fa-exclamation-triangle"></i> Merge this user into id <input type="text"
-                                                name="master_id" style="height:1.5em" size="5" value="">
-        </div>
+        {% if "merge" in moderation_actions %}
+          <div>
+              <input type="radio" name="action" value="merge"> Merge this user into id <input type="text"
+                                                  name="master_id" style="height:1.5em" size="5" value="">
+          </div>
+        {% endif %}
 
         <div class="row" style="padding-top: 1ex">
             <div class="submit">

--- a/biostar3/forum/tests/test_moderation.py
+++ b/biostar3/forum/tests/test_moderation.py
@@ -24,7 +24,7 @@ def create_post():
 
     return author, post
 
-class ModerationTests(TestCase):
+class PostModerationTests(TestCase):
     def test_user_cant_restore(self):
         "A normal user can't restore a closed post"
 
@@ -136,3 +136,269 @@ class ModerationTests(TestCase):
         self.assertTrue("move_to_answer" in reply.moderation_actions(moderator_user))
         self.assertTrue("move_to_comment" in reply.moderation_actions(moderator_user))
         self.assertTrue("move_to_question" in reply.moderation_actions(moderator_user))
+
+class UserModerationTests(TestCase):
+    def test_user_cant_moderate_users(self):
+        "A normal user can't perform any user moderation actions"
+
+        normal_user = User.objects.create(name=f.name(), email=f.email())
+        auth.add_user_attributes(normal_user)
+        target_user = User.objects.create(name=f.name(), email=f.email())
+        auth.add_user_attributes(target_user)
+
+        self.assertEqual(target_user.moderation_actions(normal_user), [])
+
+    def test_moderator_cant_moderate_admin(self):
+        "A moderator can't perform moderation actions on an admin"
+
+        moderator = User.objects.create(name=f.name(), email=f.email(), type=User.MODERATOR)
+        auth.add_user_attributes(moderator)
+        admin = User.objects.create(name=f.name(), email=f.email(), type=User.ADMIN)
+        auth.add_user_attributes(admin)
+
+        self.assertEqual(admin.moderation_actions(moderator), [])
+
+    def test_admin_cant_moderate_admin(self):
+        "An admin can't perform moderation actions on an admin"
+
+        admin1 = User.objects.create(name=f.name(), email=f.email(), type=User.ADMIN)
+        auth.add_user_attributes(admin1)
+        admin2 = User.objects.create(name=f.name(), email=f.email(), type=User.ADMIN)
+        auth.add_user_attributes(admin2)
+
+        self.assertEqual(admin2.moderation_actions(admin1), [])
+
+    def test_staff_cant_moderate_admin(self):
+        "Staff can't perform moderation actions on an admin"
+
+        staff = User.objects.create(name=f.name(), email=f.email(), is_staff=True)
+        auth.add_user_attributes(staff)
+        admin = User.objects.create(name=f.name(), email=f.email(), type=User.ADMIN)
+        auth.add_user_attributes(admin)
+
+        self.assertEqual(admin.moderation_actions(staff), [])
+
+    def test_moderator_cant_moderate_staff(self):
+        "A moderator can't perform moderation actions on staff"
+
+        moderator = User.objects.create(name=f.name(), email=f.email(), type=User.MODERATOR)
+        auth.add_user_attributes(moderator)
+        staff = User.objects.create(name=f.name(), email=f.email(), is_staff=True)
+        auth.add_user_attributes(staff)
+
+        self.assertEqual(staff.moderation_actions(moderator), [])
+
+    def test_admin_cant_moderate_staff(self):
+        "An admin can't perform moderation actions on staff"
+
+        admin = User.objects.create(name=f.name(), email=f.email(), type=User.ADMIN)
+        auth.add_user_attributes(admin)
+        staff = User.objects.create(name=f.name(), email=f.email(), is_staff=True)
+        auth.add_user_attributes(staff)
+
+        self.assertEqual(staff.moderation_actions(admin), [])
+
+    def test_staff_cant_moderate_staff(self):
+        "Staff can't perform moderation actions on staff"
+
+        staff1 = User.objects.create(name=f.name(), email=f.email(), is_staff=True)
+        auth.add_user_attributes(staff1)
+        staff2 = User.objects.create(name=f.name(), email=f.email(), is_staff=True)
+        auth.add_user_attributes(staff2)
+
+        self.assertEqual(staff2.moderation_actions(staff1), [])
+
+    def test_moderator_can_suspend_user(self):
+        "A moderator can suspend a user"
+
+        moderator = User.objects.create(name=f.name(), email=f.email(), type=User.MODERATOR)
+        auth.add_user_attributes(moderator)
+        user = User.objects.create(name=f.name(), email=f.email())
+        auth.add_user_attributes(user)
+
+        self.assertFalse(user.is_suspended)
+
+        self.assertTrue("suspend" in user.moderation_actions(moderator))
+
+    def test_admin_can_suspend_user(self):
+        "An admin can suspend a user"
+
+        admin = User.objects.create(name=f.name(), email=f.email(), type=User.ADMIN)
+        auth.add_user_attributes(admin)
+        user = User.objects.create(name=f.name(), email=f.email())
+        auth.add_user_attributes(user)
+
+        self.assertFalse(user.is_suspended)
+
+        self.assertTrue("suspend" in user.moderation_actions(admin))
+
+    def test_staff_can_suspend_user(self):
+        "Staff can suspend a user"
+
+        staff = User.objects.create(name=f.name(), email=f.email(), is_staff=True)
+        auth.add_user_attributes(staff)
+        user = User.objects.create(name=f.name(), email=f.email())
+        auth.add_user_attributes(user)
+
+        self.assertFalse(user.is_suspended)
+
+        self.assertTrue("suspend" in user.moderation_actions(staff))
+
+    def test_moderator_cant_ban_user(self):
+        "A moderator can't ban a user"
+
+        moderator = User.objects.create(name=f.name(), email=f.email(), type=User.MODERATOR)
+        auth.add_user_attributes(moderator)
+        user = User.objects.create(name=f.name(), email=f.email())
+        auth.add_user_attributes(user)
+
+        self.assertFalse(user.is_suspended)
+
+        self.assertFalse("ban" in user.moderation_actions(moderator))
+
+    def test_admin_cant_ban_user(self):
+        "An admin can't ban a user"
+
+        admin = User.objects.create(name=f.name(), email=f.email(), type=User.ADMIN)
+        auth.add_user_attributes(admin)
+        user = User.objects.create(name=f.name(), email=f.email())
+        auth.add_user_attributes(user)
+
+        self.assertFalse(user.is_suspended)
+
+        self.assertFalse("ban" in user.moderation_actions(admin))
+
+    def test_staff_can_ban_user(self):
+        "Staff can ban a user"
+
+        staff = User.objects.create(name=f.name(), email=f.email(), is_staff=True)
+        auth.add_user_attributes(staff)
+        user = User.objects.create(name=f.name(), email=f.email())
+        auth.add_user_attributes(user)
+
+        self.assertFalse(user.is_suspended)
+
+        self.assertTrue("ban" in user.moderation_actions(staff))
+
+    def test_moderator_can_reinstate_suspended_user(self):
+        "A moderator can reinstate a suspended user"
+
+        moderator = User.objects.create(name=f.name(), email=f.email(), type=User.MODERATOR)
+        auth.add_user_attributes(moderator)
+        user = User.objects.create(name=f.name(), email=f.email(), status=User.SUSPENDED)
+        auth.add_user_attributes(user)
+
+        self.assertTrue(user.is_suspended)
+
+        self.assertTrue("reinstate" in user.moderation_actions(moderator))
+
+    def test_admin_can_reinstate_suspended_user(self):
+        "An admin can reinstate a suspended user"
+
+        admin = User.objects.create(name=f.name(), email=f.email(), type=User.ADMIN)
+        auth.add_user_attributes(admin)
+        user = User.objects.create(name=f.name(), email=f.email(), status=User.SUSPENDED)
+        auth.add_user_attributes(user)
+
+        self.assertTrue(user.is_suspended)
+
+        self.assertTrue("reinstate" in user.moderation_actions(admin))
+
+    def test_staff_can_reinstate_suspended_user(self):
+        "Staff can reinstate a suspended user"
+
+        staff = User.objects.create(name=f.name(), email=f.email(), is_staff=True)
+        auth.add_user_attributes(staff)
+        user = User.objects.create(name=f.name(), email=f.email(), status=User.SUSPENDED)
+        auth.add_user_attributes(user)
+
+        self.assertTrue(user.is_suspended)
+
+        self.assertTrue("reinstate" in user.moderation_actions(staff))
+
+    def test_moderator_cant_reinstate_banned_user(self):
+        "A moderator can't reinstate a banned user"
+
+        moderator = User.objects.create(name=f.name(), email=f.email(), type=User.MODERATOR)
+        auth.add_user_attributes(moderator)
+        user = User.objects.create(name=f.name(), email=f.email(), status=User.BANNED)
+        auth.add_user_attributes(user)
+
+        self.assertTrue(user.is_suspended)
+
+        self.assertFalse("reinstate" in user.moderation_actions(moderator))
+
+    def test_admin_cant_reinstate_banned_user(self):
+        "An admin can't reinstate a banned user"
+
+        admin = User.objects.create(name=f.name(), email=f.email(), type=User.ADMIN)
+        auth.add_user_attributes(admin)
+        user = User.objects.create(name=f.name(), email=f.email(), status=User.BANNED)
+        auth.add_user_attributes(user)
+
+        self.assertTrue(user.is_suspended)
+
+        self.assertFalse("reinstate" in user.moderation_actions(admin))
+
+    def test_staff_can_reinstate_banned_user(self):
+        "Staff can reinstate a banned user"
+
+        staff = User.objects.create(name=f.name(), email=f.email(), is_staff=True)
+        auth.add_user_attributes(staff)
+        user = User.objects.create(name=f.name(), email=f.email(), status=User.BANNED)
+        auth.add_user_attributes(user)
+
+        self.assertTrue(user.is_suspended)
+
+        self.assertTrue("reinstate" in user.moderation_actions(staff))
+
+    def test_cant_reinstate_normal_user(self):
+        "Can't reinstate a user that isn't suspended or banned"
+
+        moderator = User.objects.create(name=f.name(), email=f.email(), type=User.MODERATOR)
+        auth.add_user_attributes(moderator)
+        user = User.objects.create(name=f.name(), email=f.email())
+        auth.add_user_attributes(user)
+
+        self.assertFalse(user.is_suspended)
+
+        self.assertFalse("reinstate" in user.moderation_actions(moderator))
+
+    def test_moderator_cant_merge_users(self):
+        "A moderator can't merge users"
+
+        moderator = User.objects.create(name=f.name(), email=f.email(), type=User.MODERATOR)
+        auth.add_user_attributes(moderator)
+        user1 = User.objects.create(name=f.name(), email=f.email())
+        auth.add_user_attributes(user1)
+        user2 = User.objects.create(name=f.name(), email=f.email())
+        auth.add_user_attributes(user2)
+
+        self.assertFalse("merge" in user1.moderation_actions(moderator))
+        self.assertFalse("merge" in user2.moderation_actions(moderator))
+
+    def test_admin_cant_merge_users(self):
+        "An admin can't merge users"
+
+        admin = User.objects.create(name=f.name(), email=f.email(), type=User.ADMIN)
+        auth.add_user_attributes(admin)
+        user1 = User.objects.create(name=f.name(), email=f.email())
+        auth.add_user_attributes(user1)
+        user2 = User.objects.create(name=f.name(), email=f.email())
+        auth.add_user_attributes(user2)
+
+        self.assertFalse("merge" in user1.moderation_actions(admin))
+        self.assertFalse("merge" in user2.moderation_actions(admin))
+
+    def test_staff_can_merge_users(self):
+        "Staff can merge users"
+
+        staff = User.objects.create(name=f.name(), email=f.email(), is_staff=True)
+        auth.add_user_attributes(staff)
+        user1 = User.objects.create(name=f.name(), email=f.email())
+        auth.add_user_attributes(user1)
+        user2 = User.objects.create(name=f.name(), email=f.email())
+        auth.add_user_attributes(user2)
+
+        self.assertTrue("merge" in user1.moderation_actions(staff))
+        self.assertTrue("merge" in user2.moderation_actions(staff))


### PR DESCRIPTION
This is a counterpart to the post moderation refactor in
a7af4b92. Now, only show actions that are possible given
the state of the target user and the permissions of the
moderator.

Additionally, this change prevents non-staff from
reinstating banned users, since non-staff cannot ban users.