### PR TITLE
Backport fix for un-accept behavior with multiple accepted answers

### DIFF
--- a/biostar/server/ajax.py
+++ b/biostar/server/ajax.py
@@ -88,7 +88,10 @@ def perform_vote(post, user, vote_type):
             Post.objects.filter(pk=post.root_id).update(has_accepted=True)
         else:
             Post.objects.filter(pk=post.id).update(vote_count=F('vote_count') + change, has_accepted=False)
-            Post.objects.filter(pk=post.root_id).update(has_accepted=False)
+
+            # Only set root as not accepted if there are no accepted siblings
+            if Post.objects.exclude(pk=post.root_id).filter(root_id=post.root_id, has_accepted=True).count() == 0:
+                Post.objects.filter(pk=post.root_id).update(has_accepted=False)
     else:
         Post.objects.filter(pk=post.id).update(vote_count=F('vote_count') + change)
 


### PR DESCRIPTION
When a question has multiple accepted answers, un-accepting one of
them would cause the entire question to be marked as not accepted.
Now, confirm that there are no other accepted sibling posts
before marking the question as not accepted.

This backports https://github.com/ialbert/biostar-central/pull/361