### PR TITLE
Add an option to biostar.sh to source environment variables

### DIFF
--- a/biostar.sh
+++ b/biostar.sh
@@ -1,5 +1,21 @@
 #!/bin/bash
 
+while getopts ":e:" opt; do
+  case $opt in
+    e)
+      CONFIG="run/$OPTARG.env"
+      echo "Using configuration from $CONFIG" >&2
+      source $CONFIG
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      ;;
+    :)
+      echo "-$OPTARG requires an argument" >&2
+      ;;
+  esac
+done
+
 # Environment variables must be set externally.
 if [ -z "$BIOSTAR_HOME" ]; then
     echo "(!) Environment variables not set. See the README.md."


### PR DESCRIPTION
Previously environment variables would have to be sourced in
a separate command. This introduces needless complexity into
runscripts and pollutes the namespace of the shell when
developing. Now allow the user to specify the environment
file to source from run/ with the -e option.