### PR TITLE
Backport addition of -e option to biostar.sh

### DIFF
--- a/biostar.sh
+++ b/biostar.sh
@@ -1,9 +1,25 @@
 #!/bin/bash
 
+while getopts ":e:" opt; do
+  case $opt in
+    e)
+      CONFIG="$OPTARG"
+      echo "Using configuration from $CONFIG" >&2
+      source $CONFIG
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      ;;
+    :)
+      echo "-$OPTARG requires an argument" >&2
+      ;;
+  esac
+done
+
 # Environment variables must be set externally.
 if [ -z "$BIOSTAR_HOME" ]; then
     echo "(!) environment variables not set."
-    echo "(!) try: source conf/defaults.env"
+    echo "(!) Try: $(basename $0) -e conf/defaults.env"
     exit 1
 fi
 


### PR DESCRIPTION
This option allows sourcing of environment variables directly from
biostar.sh, rather than a separate command that pollutes the shell
namespace and makes runscripts more complex.

Backports https://github.com/ialbert/biostar-central/pull/368 and
https://github.com/ialbert/biostar-central/pull/369