### PR TITLE
CSS changes to userbar and navbar

### DIFF
--- a/biostar3/forum/static/site.css
+++ b/biostar3/forum/static/site.css
@@ -518,7 +518,49 @@ ul.dropdown ul.items li :hover {
   margin-bottom: 0.5ex;
   border-bottom: 1px solid #cdcdcd;
 }
-#userbar,
+#userbar {
+  width: 100%;
+  display: flex;
+  display: -webkit-flex;
+  justify-content: space-between;
+  -webkit-justify-content: space-between;
+  margin-bottom: 2px;
+}
+#userbar .icon {
+  font-size: 2em;
+}
+#userbar .navlabel {
+  font-size: small;
+}
+#userbar .signin {
+  border: 1px solid #d6e9c6;
+  border-radius: 4px;
+  color: #3c763d;
+  background-color: #dff0d8;
+}
+#userbar .signin:hover {
+  color: #5b8c3e;
+  background-color: red;
+  cursor: pointer;
+  border-radius: 4px;
+}
+#userbar .item {
+  margin-top: 0.5ex;
+  float: left;
+  text-align: center;
+}
+#userbar .item a {
+  display: inline-block;
+  padding: 1ex;
+}
+#userbar .item a:hover {
+  background-color: #EFEFEF;
+  cursor: pointer;
+  border-radius: 4px;
+}
+#userbar .last {
+  float: right;
+}
 #navbar {
   width: 100%;
   display: flex;
@@ -527,46 +569,38 @@ ul.dropdown ul.items li :hover {
   -webkit-justify-content: space-between;
   margin-bottom: 2px;
 }
-#userbar .icon,
 #navbar .icon {
   font-size: 2em;
 }
-#userbar .navlabel,
 #navbar .navlabel {
   font-size: small;
 }
-#userbar .signin,
 #navbar .signin {
   border: 1px solid #d6e9c6;
   border-radius: 4px;
   color: #3c763d;
   background-color: #dff0d8;
 }
-#userbar .signin:hover,
 #navbar .signin:hover {
   color: #5b8c3e;
   background-color: red;
   cursor: pointer;
   border-radius: 4px;
 }
-#userbar .item,
 #navbar .item {
   margin-top: 0.5ex;
   float: left;
   text-align: center;
 }
-#userbar .item a,
 #navbar .item a {
   display: inline-block;
   padding: 1ex;
 }
-#userbar .item a:hover,
 #navbar .item a:hover {
   background-color: #EFEFEF;
   cursor: pointer;
   border-radius: 4px;
 }
-#userbar .last,
 #navbar .last {
   float: right;
 }

--- a/biostar3/forum/static/site.css
+++ b/biostar3/forum/static/site.css
@@ -524,24 +524,6 @@ ul.dropdown ul.items li :hover {
 #userbar *.glow:hover {
   color: #5b8c3e;
 }
-#userbar .icon {
-  font-size: 2em;
-}
-#userbar .navlabel {
-  font-size: small;
-}
-#userbar .signin {
-  border: 1px solid #d6e9c6;
-  border-radius: 4px;
-  color: #3c763d;
-  background-color: #dff0d8;
-}
-#userbar .signin:hover {
-  color: #5b8c3e;
-  background-color: red;
-  cursor: pointer;
-  border-radius: 4px;
-}
 #userbar .item {
   margin-top: 0.5ex;
   float: left;
@@ -555,9 +537,6 @@ ul.dropdown ul.items li :hover {
   background-color: #EFEFEF;
   cursor: pointer;
   border-radius: 4px;
-}
-#userbar .last {
-  float: right;
 }
 #navbar {
   width: 100%;
@@ -573,18 +552,6 @@ ul.dropdown ul.items li :hover {
 #navbar .navlabel {
   font-size: small;
 }
-#navbar .signin {
-  border: 1px solid #d6e9c6;
-  border-radius: 4px;
-  color: #3c763d;
-  background-color: #dff0d8;
-}
-#navbar .signin:hover {
-  color: #5b8c3e;
-  background-color: red;
-  cursor: pointer;
-  border-radius: 4px;
-}
 #navbar .item {
   margin-top: 0.5ex;
   float: left;
@@ -598,9 +565,6 @@ ul.dropdown ul.items li :hover {
   background-color: #EFEFEF;
   cursor: pointer;
   border-radius: 4px;
-}
-#navbar .last {
-  float: right;
 }
 #panel {
   padding: 0.5ex 0em 1ex 0ex;

--- a/biostar3/forum/static/site.css
+++ b/biostar3/forum/static/site.css
@@ -514,7 +514,7 @@ ul.dropdown ul.items li :hover {
   display: -webkit-flex;
   justify-content: space-between;
   -webkit-justify-content: space-between;
-  margin-bottom: 2px;
+  margin-bottom: 10px;
 }
 #userbar *.glow {
   color: white;

--- a/biostar3/forum/static/site.css
+++ b/biostar3/forum/static/site.css
@@ -519,8 +519,7 @@ ul.dropdown ul.items li :hover {
   border-bottom: 1px solid #cdcdcd;
 }
 #userbar,
-#navbar,
-#topics {
+#navbar {
   width: 100%;
   display: flex;
   display: -webkit-flex;
@@ -529,54 +528,46 @@ ul.dropdown ul.items li :hover {
   margin-bottom: 2px;
 }
 #userbar .icon,
-#navbar .icon,
-#topics .icon {
+#navbar .icon {
   font-size: 2em;
 }
 #userbar .navlabel,
-#navbar .navlabel,
-#topics .navlabel {
+#navbar .navlabel {
   font-size: small;
 }
 #userbar .signin,
-#navbar .signin,
-#topics .signin {
+#navbar .signin {
   border: 1px solid #d6e9c6;
   border-radius: 4px;
   color: #3c763d;
   background-color: #dff0d8;
 }
 #userbar .signin:hover,
-#navbar .signin:hover,
-#topics .signin:hover {
+#navbar .signin:hover {
   color: #5b8c3e;
   background-color: red;
   cursor: pointer;
   border-radius: 4px;
 }
 #userbar .item,
-#navbar .item,
-#topics .item {
+#navbar .item {
   margin-top: 0.5ex;
   float: left;
   text-align: center;
 }
 #userbar .item a,
-#navbar .item a,
-#topics .item a {
+#navbar .item a {
   display: inline-block;
   padding: 1ex;
 }
 #userbar .item a:hover,
-#navbar .item a:hover,
-#topics .item a:hover {
+#navbar .item a:hover {
   background-color: #EFEFEF;
   cursor: pointer;
   border-radius: 4px;
 }
 #userbar .last,
-#navbar .last,
-#topics .last {
+#navbar .last {
   float: right;
 }
 #panel {

--- a/biostar3/forum/static/site.css
+++ b/biostar3/forum/static/site.css
@@ -495,17 +495,6 @@ ul.dropdown ul.items li :hover {
   margin-top: 5px;
   width: 299px;
 }
-#userbar {
-  border-top: 1px solid #efefef;
-}
-#userbar *.glow {
-  color: white;
-  background-color: #5b8c3e;
-  border-radius: 25px;
-}
-#userbar *.glow:hover {
-  color: #5b8c3e;
-}
 #votelist .item {
   padding: 1ex;
   font-size: larger;
@@ -519,12 +508,21 @@ ul.dropdown ul.items li :hover {
   border-bottom: 1px solid #cdcdcd;
 }
 #userbar {
+  border-top: 1px solid #efefef;
   width: 100%;
   display: flex;
   display: -webkit-flex;
   justify-content: space-between;
   -webkit-justify-content: space-between;
   margin-bottom: 2px;
+}
+#userbar *.glow {
+  color: white;
+  background-color: #5b8c3e;
+  border-radius: 25px;
+}
+#userbar *.glow:hover {
+  color: #5b8c3e;
 }
 #userbar .icon {
   font-size: 2em;

--- a/biostar3/forum/static/site.less
+++ b/biostar3/forum/static/site.less
@@ -572,7 +572,66 @@ ul.dropdown {
   border-bottom: 1px solid lighten(@MUTED_TEXT_COLOR, 30);
 }
 
-#userbar, #navbar {
+#userbar {
+  width: 100%;
+  display: flex;
+  display:-webkit-flex;
+  justify-content: space-between;
+  -webkit-justify-content: space-between;
+  margin-bottom: 2px;
+  //min-width:4em;
+  .icon {
+    font-size: 2em;
+  }
+
+  .navlabel {
+    font-size: small;
+  }
+
+  .signin {
+    border: 1px solid #d6e9c6;
+    border-radius: 4px;
+    color: #3c763d;
+    background-color: #dff0d8;
+
+    &:hover {
+      color: #5b8c3e;
+      //color: red;
+      //background-color: #EFEFEF;
+      background-color: red;
+      cursor: pointer;
+      border-radius: 4px;
+    }
+  }
+
+  .signout {
+    //border: 1px solid pink;
+    //border-radius: 4px;
+  }
+
+  .item {
+    margin-top: 0.5ex;
+    float: left;
+    text-align: center;
+
+    a {
+      display: inline-block;
+      padding: 1ex;
+    }
+
+    a:hover {
+      background-color: #EFEFEF;
+      cursor: pointer;
+      border-radius: 4px;
+    }
+  }
+
+  .last {
+    float: right;
+  }
+}
+
+#navbar {
   width: 100%;
   display: flex;
   display:-webkit-flex;

--- a/biostar3/forum/static/site.less
+++ b/biostar3/forum/static/site.less
@@ -568,7 +568,7 @@ ul.dropdown {
   justify-content: space-between;
   -webkit-justify-content: space-between;
   margin-bottom: 2px;
-  //min-width:4em;
+
   *.glow {
     color: white;
     background-color: @ANSWERED_COLOR;
@@ -594,17 +594,10 @@ ul.dropdown {
 
     &:hover {
       color: #5b8c3e;
-      //color: red;
-      //background-color: #EFEFEF;
       background-color: red;
       cursor: pointer;
       border-radius: 4px;
     }
-  }
-
-  .signout {
-    //border: 1px solid pink;
-    //border-radius: 4px;
   }
 
   .item {
@@ -636,7 +629,6 @@ ul.dropdown {
   justify-content: space-between;
   -webkit-justify-content: space-between;
   margin-bottom: 2px;
-  //min-width:4em;
   .icon {
     font-size: 2em;
   }
@@ -653,17 +645,10 @@ ul.dropdown {
 
     &:hover {
       color: #5b8c3e;
-      //color: red;
-      //background-color: #EFEFEF;
       background-color: red;
       cursor: pointer;
       border-radius: 4px;
     }
-  }
-
-  .signout {
-    //border: 1px solid pink;
-    //border-radius: 4px;
   }
 
   .item {

--- a/biostar3/forum/static/site.less
+++ b/biostar3/forum/static/site.less
@@ -567,7 +567,7 @@ ul.dropdown {
   display:-webkit-flex;
   justify-content: space-between;
   -webkit-justify-content: space-between;
-  margin-bottom: 2px;
+  margin-bottom: 10px;
 
   *.glow {
     color: white;

--- a/biostar3/forum/static/site.less
+++ b/biostar3/forum/static/site.less
@@ -543,18 +543,6 @@ ul.dropdown {
   }
 }
 
-#userbar {
-  border-top:1px solid #efefef;
-  *.glow {
-    color: white;
-    background-color: @ANSWERED_COLOR;
-    border-radius: 25px;
-    &:hover {
-      color: @ANSWERED_COLOR;
-    }
-  }
-}
-
 #votelist {
   .item {
     padding: 1ex;
@@ -573,6 +561,7 @@ ul.dropdown {
 }
 
 #userbar {
+  border-top:1px solid #efefef;
   width: 100%;
   display: flex;
   display:-webkit-flex;
@@ -580,6 +569,15 @@ ul.dropdown {
   -webkit-justify-content: space-between;
   margin-bottom: 2px;
   //min-width:4em;
+  *.glow {
+    color: white;
+    background-color: @ANSWERED_COLOR;
+    border-radius: 25px;
+    &:hover {
+      color: @ANSWERED_COLOR;
+    }
+  }
+
   .icon {
     font-size: 2em;
   }

--- a/biostar3/forum/static/site.less
+++ b/biostar3/forum/static/site.less
@@ -572,7 +572,7 @@ ul.dropdown {
   border-bottom: 1px solid lighten(@MUTED_TEXT_COLOR, 30);
 }
 
-#userbar, #navbar, #topics {
+#userbar, #navbar {
   width: 100%;
   display: flex;
   display:-webkit-flex;
@@ -736,8 +736,3 @@ there.
     width: auto;
   }
 }
-
-
-
-
-

--- a/biostar3/forum/static/site.less
+++ b/biostar3/forum/static/site.less
@@ -578,28 +578,6 @@ ul.dropdown {
     }
   }
 
-  .icon {
-    font-size: 2em;
-  }
-
-  .navlabel {
-    font-size: small;
-  }
-
-  .signin {
-    border: 1px solid #d6e9c6;
-    border-radius: 4px;
-    color: #3c763d;
-    background-color: #dff0d8;
-
-    &:hover {
-      color: #5b8c3e;
-      background-color: red;
-      cursor: pointer;
-      border-radius: 4px;
-    }
-  }
-
   .item {
     margin-top: 0.5ex;
     float: left;
@@ -615,10 +593,6 @@ ul.dropdown {
       cursor: pointer;
       border-radius: 4px;
     }
-  }
-
-  .last {
-    float: right;
   }
 }
 
@@ -637,20 +611,6 @@ ul.dropdown {
     font-size: small;
   }
 
-  .signin {
-    border: 1px solid #d6e9c6;
-    border-radius: 4px;
-    color: #3c763d;
-    background-color: #dff0d8;
-
-    &:hover {
-      color: #5b8c3e;
-      background-color: red;
-      cursor: pointer;
-      border-radius: 4px;
-    }
-  }
-
   .item {
     margin-top: 0.5ex;
     float: left;
@@ -666,10 +626,6 @@ ul.dropdown {
       cursor: pointer;
       border-radius: 4px;
     }
-  }
-
-  .last {
-    float: right;
   }
 }
 


### PR DESCRIPTION
Cleans up a bunch of old/duplicate style declarations for `#userbar` and `#navbar`. Deletes the obsolete `#topics` CSS rules.

The change I was actually trying to make is in the last commit: increase the spacing between the userbar and the content below it, which felt squeezed together.