### PR TITLE
Refactor views to use user_link everywhere

### DIFF
--- a/biostar3/forum/models.py
+++ b/biostar3/forum/models.py
@@ -192,6 +192,14 @@ class User(AbstractBaseUser, PermissionsMixin):
     def get_short_name(self):
         return self.name
 
+    @property
+    def marker(self):
+        if self.is_admin:
+            return "\u2666\u2666" # double diamond
+        elif self.is_moderator:
+            return "\u2666" # single diamond
+        return "\u2022" # single bullet
+
     def post_count(self, types):
         return Post.objects.filter(type__in=types, author=self).count()
 

--- a/biostar3/forum/templates/post_unit.html
+++ b/biostar3/forum/templates/post_unit.html
@@ -22,8 +22,7 @@
             {{ post.creation_date|time_ago }}
         </div>
         <div>
-            <a href="{{ post.author.get_absolute_url }}">{{ post.author.name }}</a>
-            {% user_marker post.author %} {{ post.author.score|bignum }}
+            {% user_link post.author %}
         </div>
         <div>
             {{ post.author.profile.location }}

--- a/biostar3/forum/templates/recent_replies.html
+++ b/biostar3/forum/templates/recent_replies.html
@@ -5,9 +5,7 @@
     {% for post in posts %}
         <li>
             {{ post.lastedit_date|time_ago }} <a href="{{ post.get_absolute_url }}">{{ post.title}}</a>
-            by
-            <a href="{{post.author.get_absolute_url}}">{{ post.author.name }}</a>
-            &bull; {{ post.author.score|bignum }}
+            by {% user_link post.author %}
         	<em>
                 {{ post.content|striptags|truncatewords:25 }}
             </em>

--- a/biostar3/forum/templates/templatetags/user_link.html
+++ b/biostar3/forum/templates/templatetags/user_link.html
@@ -1,4 +1,11 @@
 {%  load widgets %}
 {#  Renders a user link #}
-<a href="{{ user.get_absolute_url }}">{{ user.name }}</a> {%  user_marker user %}
-<b>{{ user.score|bignum }}</b>
+{% if unwrap %}
+  {{ user.name }}
+{% else %}
+  <a href="{{ user.get_absolute_url }}">{{ user.name }}</a>
+{% endif %}
+{{ user.marker }}
+{% if show_score %}
+  <b>{{ user.score|bignum }}</b>
+{% endif %}

--- a/biostar3/forum/templates/user_bar.html
+++ b/biostar3/forum/templates/user_bar.html
@@ -17,7 +17,7 @@
                 {% if user.is_authenticated %}
 
                     <div class="item tooltip" title="Your Account" data-tooltip-direction="top">
-                        <a href="{% url "user_view" pk=user.id %}"><i class="fa fa-user"></i> {{ user.name }}  {%  user_marker user %}
+                        <a href="{% url "user_view" pk=user.id %}"><i class="fa fa-user"></i> {% user_link user show_score=False unwrap=True %}
                         </a>
                     </div>
 

--- a/biostar3/forum/templates/user_list.html
+++ b/biostar3/forum/templates/user_list.html
@@ -27,7 +27,7 @@
                         </div>
 
                         <div>
-                            <a href="{{ user.get_absolute_url }}">{{ user.name }}</a> {%  user_marker user %} <b>{{ user.score|bignum }}</b>
+                            {% user_link user %}
                         </div>
 
                         <div class="visited">

--- a/biostar3/forum/templates/user_view.html
+++ b/biostar3/forum/templates/user_view.html
@@ -19,7 +19,7 @@
 
         <div class="row">
             <div class="title center {% user_status_css target %}">
-                User: {{ target.name }} {%  user_marker target %}
+                User: {% user_link target show_score=False unwrap=True %}
                 {% if target.is_suspended %}
                     (<i class="fa fa-exclamation-triangle"></i> {{ target.get_status_display|lower }})
                 {% endif %}

--- a/biostar3/forum/templatetags/widgets.py
+++ b/biostar3/forum/templatetags/widgets.py
@@ -69,16 +69,8 @@ def post_unit(context, post, comments):
 
 
 @register.inclusion_tag('templatetags/user_link.html')
-def user_link(user):
-    return dict(user=user)
-
-@register.simple_tag
-def user_marker(user):
-    if user.is_admin:
-        return "&diams;&diams;"
-    elif user.is_moderator:
-        return "&diams;"
-    return "&bull;"
+def user_link(user, show_score=True, unwrap=False):
+    return dict(user=user, show_score=show_score, unwrap=unwrap)
 
 @register.filter
 def on_value(value):


### PR DESCRIPTION
Previously the user links were manually reproduced in several
different files, in some cases leading to inconsistent results
(mainly bolding of scores). This refactors all such places to
use user_link.

Additionally, the user_marker tag has been eliminated. The
method user.marker replicates its functionality and can be used
outside of view code.