### PR TITLE
Do not allow probing to discover email addresses

### DIFF
--- a/biostar3/forum/user_views.py
+++ b/biostar3/forum/user_views.py
@@ -200,14 +200,8 @@ def sign_up(request):
             messages.error(request, "This user account has been disabled")
             return login_redirect
 
-    if User.objects.filter(email=email).first():
-        # See if the email actually exists.
-        messages.error(request, "Incorrect user password.")
-        return login_redirect
-
     if not signup:
-        # The user has not requested a sigup.
-        messages.error(request, "If you want to create an account check the signup checkbox.")
+        messages.error(request, "Incorrect email address or password.")
         return login_redirect
 
     try:

--- a/biostar3/forum/user_views.py
+++ b/biostar3/forum/user_views.py
@@ -210,13 +210,6 @@ def sign_up(request):
         messages.error(request, "If you want to create an account check the signup checkbox.")
         return login_redirect
 
-    # Try to sign up the user
-    user = User.objects.filter(email=email).first()
-    if user:
-        # The email exists so the password must not match
-        messages.error(request, "User password is not correct")
-        return login_redirect
-
     try:
         # Now sign up and log in the user.
         user = User.objects.create(email=email)


### PR DESCRIPTION
The previous implementation of login would return different
error messages depending on whether the email address was
already attached to an account in the database. This would
allow malicious actors to discover which email addresses are
used for Biostar accounts, violating user privacy.

This commit replaces this logic with a generic error if
either the email address or password are incorrect.
