### PR TITLE
Refactor and test incoming mail handler

### DIFF
--- a/biostar3/forum/mailer.py
+++ b/biostar3/forum/mailer.py
@@ -27,6 +27,7 @@ from django.core.mail.backends import smtp
 from .models import *
 from . import auth
 from biostar3.utils.compat import *
+from biostar3.utils.incoming_mail import IncomingMail
 
 logger = logging.getLogger("biostar")
 
@@ -158,7 +159,7 @@ class EmailTemplate(object):
 
         if token:
             # Add reply to token to header.
-            reply_to = settings.EMAIL_ADDRESS_PATTERN.format("reply", token, "submit")
+            reply_to = settings.EMAIL_ADDRESS_PATTERN.format(IncomingMail.REPLY, token, "submit")
             headers.update({'Reply-To': reply_to})
 
         # Fall back to defaults

--- a/biostar3/tests/utils/test_incoming_mail.py
+++ b/biostar3/tests/utils/test_incoming_mail.py
@@ -1,0 +1,135 @@
+from django.test import TestCase
+
+from biostar3.utils.incoming_mail import IncomingMail, IncomingMailException
+from biostar3.forum.models import User, ReplyToken
+from biostar3.forum import auth
+
+from faker import Factory
+f = Factory.create()
+
+class IncomingMailTests(TestCase):
+    def test_empty_mail(self):
+        with self.assertRaises(IncomingMailException):
+            IncomingMail.from_raw('')
+
+    def test_valid_address(self):
+        data = dict(
+            subject = f.sentence(),
+            text = f.sentence(),
+            to_address = 'action+token+group@biostar.test'
+        )
+
+        IncomingMail(data)
+
+    def test_short_address(self):
+        data = dict(
+            subject = f.sentence(),
+            text = f.sentence(),
+            to_address = 'action+token@biostar.test'
+        )
+
+        with self.assertRaisesRegexp(IncomingMailException, '\[to_address\]'):
+            IncomingMail(data)
+
+    def test_long_address(self):
+        data = dict(
+            subject = f.sentence(),
+            text = f.sentence(),
+            to_address = 'action+token+group+extra@biostar.test'
+        )
+
+        with self.assertRaisesRegexp(IncomingMailException, '\[to_address\]'):
+            IncomingMail(data)
+
+    def test_remove_quoted_with_quote(self):
+        reply_text = f.sentence()
+        quote_text = f.sentence()
+        text_with_quote = "{}\n\n> {}".format(reply_text, quote_text)
+
+        data = dict(
+            subject = f.sentence(),
+            text = text_with_quote,
+            to_address = 'action+token+group@biostar.test'
+        )
+
+        mail = IncomingMail(data)
+
+        self.assertRegexpMatches(mail.text, reply_text)
+        self.assertRegexpMatches(mail.text, quote_text)
+
+        mail.remove_quoted_text()
+
+        self.assertRegexpMatches(mail.text, reply_text)
+        self.assertNotRegexpMatches(mail.text, quote_text)
+
+    def test_remove_quoted_without_quote(self):
+        reply_text = f.sentence()
+
+        data = dict(
+            subject = f.sentence(),
+            text = reply_text,
+            to_address = 'action+token+group@biostar.test'
+        )
+
+        mail = IncomingMail(data)
+
+        self.assertRegexpMatches(mail.text, reply_text)
+
+        mail.remove_quoted_text()
+
+        self.assertRegexpMatches(mail.text, reply_text)
+
+    def test_new_action_invalid_token(self):
+        invalid_token = 'INVALID'
+        data = dict(
+            subject = f.sentence(),
+            text = f.sentence(),
+            to_address = '{}+{}+group@biostar.test'.format(IncomingMail.NEW, invalid_token)
+        )
+
+        mail = IncomingMail(data)
+
+        with self.assertRaisesRegexp(IncomingMailException, '\[author\]'):
+            mail.perform_action()
+
+    def test_new_action_creates_post(self):
+        user = User.objects.create(name=f.name(), email=f.email())
+        data = dict(
+            subject = f.sentence(),
+            text = f.sentence(),
+            to_address = '{}+{}+group@biostar.test'.format(IncomingMail.NEW, user.profile.uuid)
+        )
+
+        mail = IncomingMail(data)
+        post = mail.perform_action()
+
+        self.assertEqual(post.author, user)
+
+    def test_reply_action_invalid_token(self):
+        invalid_token = 'INVALID'
+        data = dict(
+            subject = f.sentence(),
+            text = f.sentence(),
+            to_address = '{}+{}+group@biostar.test'.format(IncomingMail.REPLY, invalid_token)
+        )
+
+        mail = IncomingMail(data)
+
+        with self.assertRaisesRegexp(IncomingMailException, '\[reply_token\]'):
+            mail.perform_action()
+
+    def test_reply_action_creates_post(self):
+        user = User.objects.create(name=f.name(), email=f.email())
+        toplevel_post = auth.create_toplevel_post(data=dict(title=f.sentence(), content=f.sentence()), user=user)
+        reply_token = ReplyToken.objects.create(user=user, post=toplevel_post)
+        data = dict(
+            subject = f.sentence(),
+            text = f.sentence(),
+            to_address = '{}+{}+group@biostar.test'.format(IncomingMail.REPLY, reply_token.token)
+        )
+
+        mail = IncomingMail(data)
+        post = mail.perform_action()
+
+        self.assertEqual(post.author, user)
+        self.assertEqual(post.parent, toplevel_post)

--- a/biostar3/utils/incoming_mail.py
+++ b/biostar3/utils/incoming_mail.py
@@ -1,0 +1,83 @@
+import logging
+from pyzmail import PyzMessage
+
+from biostar3.utils.email_reply_parser import EmailReplyParser
+from biostar3.forum.models import User, ReplyToken
+from biostar3.forum import auth
+
+logger = logging.getLogger("biostar")
+
+class IncomingMailException(Exception):
+    def __init__(self, kind, msg):
+        self.kind = kind
+        self.msg = msg
+    def __str__(self):
+        return "Incoming Mail Error [{}]: {}".format(self.kind, self.msg)
+
+class IncomingMail:
+    NEW = "new"
+    REPLY = "reply"
+    ACTIONS = [NEW, REPLY]
+
+    @staticmethod
+    def from_raw(content):
+        data = dict()
+
+        try:
+            msg = PyzMessage.factory(content)
+        except Exception as exc:
+            logger.error(exc)
+            content = content.encode('utf8', errors='ignore')
+            msg = PyzMessage.factory(content)
+
+        try:
+            data['subject'] = msg.get_subject()
+        except Exception as exc:
+            raise IncomingMailException("subject", exc)
+
+        try:
+            data['to_address'] = msg.get_addresses('to')[0][1]
+        except Exception as exc:
+            raise IncomingMailException("to_address", exc)
+
+        try:
+            part = msg.text_part or msg.html_part
+            enc = part.charset
+            data['text'] = part.get_payload().decode(enc)
+        except Exception as exc:
+            raise IncomingMailException("text", exc)
+
+        return IncomingMail(data)
+
+    def __init__(self, data):
+        self.subject = data.get('subject')
+
+        try:
+            self.action, self.token, self.group = data.get('to_address').split('@')[0].split('+')
+        except Exception as exc:
+            raise IncomingMailException("to_address", exc)
+
+        self.text = data.get('text')
+
+    def remove_quoted_text(self):
+        self.text = EmailReplyParser.parse_reply(self.text)
+
+    def perform_action(self):
+        if not self.action in IncomingMail.ACTIONS:
+            raise IncomingMailException("action", self.action)
+
+        if self.action == IncomingMail.NEW:
+            # The token must match a users uuid.
+            author = User.objects.filter(profile__uuid=self.token).first()
+            if not author:
+                raise IncomingMailException("author", "{} does not exist".format(self.token))
+
+            # Create the post in the usergroup
+            data = dict(title=self.subject, content=self.text, tags="via email")
+            return auth.create_toplevel_post(data=data, user=author)
+        elif self.action == IncomingMail.REPLY:
+            reply_token = ReplyToken.objects.filter(token=self.token).first()
+            if not reply_token:
+                raise IncomingMailException("reply_token", "{} does not exist".format(self.token))
+
+            return auth.create_content_post(content=self.text, parent=reply_token.post, user=reply_token.user)


### PR DESCRIPTION
Break logic for consuming emails POSTed to /site/incoming/email/ into
a separate util class and add tests for that class.

Also use the action constant when generating the reply-to address for
outgoing notification mails.