### PR TITLE
Added language detection configuration.

### DIFF
--- a/biostar/apps/posts/views.py
+++ b/biostar/apps/posts/views.py
@@ -33,9 +33,12 @@ def english_only(text):
 
 
 def valid_language(text):
-    lang = langdetect.detect(text)
-    if lang != 'en':
-        raise ValidationError('Not recognized as English Language!')
+    supported_languages = settings.LANGUAGE_DETECTION
+    if supported_languages:
+        lang = langdetect.detect(text)
+        if lang not in supported_languages:
+            raise ValidationError(
+                    'Language "{0}" is not one of the supported languages {1}!'.format(lang, supported_languages))
 
 logger = logging.getLogger(__name__)
 

--- a/biostar/settings/base.py
+++ b/biostar/settings/base.py
@@ -146,6 +146,9 @@ TIME_ZONE = 'America/Chicago'
 # http://www.i18nguy.com/unicode/language-identifiers.html
 LANGUAGE_CODE = 'en-us'
 
+# Configure language detection
+LANGUAGE_DETECTION = ['en']
+
 # These parameters will be inserted into the database automatically.
 SITE_ID = 1
 SITE_NAME = "Site Name"


### PR DESCRIPTION
LANGUAGE_DETECTION in the settings file defines a list of supported languages in the detection.
If such list is empty language detection is not done.
The default stays as it was (english only)