### PR TITLE
improved recipe edit and manage access pages

### DIFF
--- a/biostar/accounts/models.py
+++ b/biostar/accounts/models.py
@@ -124,7 +124,7 @@ class Profile(models.Model):
     def save(self, *args, **kwargs):
         self.uid = self.uid or util.get_uuid(8)
         self.html = self.html or mistune.markdown(self.text)
-        self.max_upload_size = self.max_upload_size or settings.MAX_UPLOAD_SIZE
+        self.max_upload_size = self.max_upload_size or self.get_upload_size()
         self.name = self.name or self.user.first_name or self.user.email.split("@")[0]
         self.date_joined = self.date_joined or now()
         self.last_login = self.last_login or now() #- timedelta(days=1)
@@ -134,6 +134,17 @@ class Profile(models.Model):
     def is_active(self):
         return self.state != Profile.DEACTIVATED
 
+    def get_upload_size(self):
+
+        # Admin users upload limit
+        if self.user.is_superuser or self.user.is_staff:
+            return settings.ADMIN_UPLOAD_SIZE
+        # Trusted users upload limit
+        if self.user.profile.trusted:
+            return settings.TRUSTED_UPLOAD_SIZE
+
+        # Get the default upload limit
+        return settings.MAX_UPLOAD_SIZE
 
     @property
     def is_moderator(self):

--- a/biostar/accounts/settings.py
+++ b/biostar/accounts/settings.py
@@ -28,6 +28,12 @@ DEFAULT_FROM_EMAIL = f"{ADMIN_NAME} <{ADMIN_EMAIL}>"
 # In MB
 MAX_UPLOAD_SIZE = 10
 
+# Trusted users upload limit in MB.
+TRUSTED_UPLOAD_SIZE = 500
+
+# Admin users upload limit in MB
+ADMIN_UPLOAD_SIZE = 1000
+
 MESSAGES_PER_PAGE = 5
 
 # Set RECAPTCH keys here.

--- a/biostar/accounts/views.py
+++ b/biostar/accounts/views.py
@@ -44,14 +44,12 @@ def edit_profile(request):
 
     if request.method == "POST":
         form = forms.EditProfile(data=request.POST, user=user, initial=initial, files=request.FILES)
-        #print(request.POST)
+
         if form.is_valid():
             # Update the email and username of User object.
             email = form.cleaned_data['email']
             username = form.cleaned_data["username"]
             User.objects.filter(pk=user.pk).update(username=username, email=email)
-            print(form.cleaned_data['my_tags'], form.cleaned_data['my_tags'])
-
             # Change verification if email has been edited.
             email_verified = False if user.email != initial["email"] else user.profile.email_verified
             # Update user information in Profile object.

--- a/biostar/recipes/admin.py
+++ b/biostar/recipes/admin.py
@@ -89,7 +89,7 @@ class AnalysisAdmin(admin.ModelAdmin):
 
     fieldsets = (("Analysis Metadata",
                   {'fields': ("name", "owner", 'project', ("uid", "rank"),
-                              ("deleted", "security"), "image"),
+                              ("deleted", "security"), "image", 'root'),
                    "classes": ('extrapretty')}
                   ),
 

--- a/biostar/recipes/factory.py
+++ b/biostar/recipes/factory.py
@@ -192,6 +192,14 @@ def data_field_generator(field, project, type="", extras=[]):
         choices = extras + [(d.id, d.name) for d in datamap.values()]
         return choices
 
+    label = field.get('label', '')
+    types = type.split(',')
+    # Add the data type to the label.
+    if type:
+        types = ', '.join(types)
+        label = f'{label}  ( {types} )'
+        field['label'] = label
+
     # Returns a SELECT field with the choices.
     return select_field(field, choicefunc=choice_func)
 

--- a/biostar/recipes/settings.py
+++ b/biostar/recipes/settings.py
@@ -39,7 +39,7 @@ MAX_UPLOAD_SIZE = 10
 # Deployment specific parameters.
 PROTOCOL = "http"
 HTTP_PORT = '8000'
-BASE_URL = f"{PROTOCOL}://{SITE_DOMAIN}{HTTP_PORT}"
+BASE_URL = f"{PROTOCOL}://{SITE_DOMAIN}:{HTTP_PORT}"
 
 FTP_HOST = "localhost"
 FTP_PORT = 8021

--- a/biostar/recipes/static/engine.css
+++ b/biostar/recipes/static/engine.css
@@ -98,7 +98,8 @@ body {
 .listing.ribbon.label{
     position: absolute;
     margin-left: 2px;
-
+    -webkit-box-shadow: 0 2px 4px 0 rgba(34,36,38,.12), 0 2px 10px 0 rgba(34,36,38,.15);
+    box-shadow: 0 2px 2px 0 rgba(34,36,38,.12), 0 2px 10px 0 rgba(34,36,38,.15);
 
 }
 
@@ -120,6 +121,8 @@ body {
 .viewing.ribbon.label{
     position: absolute;
     left: calc(100% + 1.2em);
+    -webkit-box-shadow: 0 2px 4px 0 rgba(34,36,38,.12), 0 2px 10px 0 rgba(34,36,38,.15);
+    box-shadow: 0 2px 2px 0 rgba(34,36,38,.12), 0 2px 10px 0 rgba(34,36,38,.15);
 }
 
 .copied.item{

--- a/biostar/recipes/templates/project_list.html
+++ b/biostar/recipes/templates/project_list.html
@@ -23,11 +23,12 @@
         <a class="ui {{ private }} item" href="{% url 'project_list_private' %}">
             <i class=" briefcase icon"></i><span class="tablet">Private Projects</span>
         </a>
-        {% if user.is_superuser %}
+        {% if user.is_authenticated  and user.profile.trusted %}
             <a class="ui blue item" href="{% url 'root_list' %}">
                 <i class="download  icon"></i><span class="tablet">Import</span>
             </a>
         {% endif %}
+
         {% if user.is_authenticated %}
             <div class="right menu">
                 <a class="ui {% activate 'recipe_create' active %}  active item" href="{% url 'project_create' %}">

--- a/biostar/recipes/templates/recipe_edit.html
+++ b/biostar/recipes/templates/recipe_edit.html
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block headtitle %}
-    {% if name %}
+    {% if recipe %}
         Editing: {{ name }}
     {% else %}
         Creating
@@ -18,11 +18,18 @@
 {% endblock %}
 
 {% block content %}
+
     <form method="post" class="ui form" action="{{ action_url }}" enctype='multipart/form-data'>
 
-
         <div class="narrow">
+            {% if recipe %}
+                <div class="ui raised segment">
+                    {% recipe_details recipe %}
+                </div>
+            {% endif %}
+
             <div class="ui raised segment inputcolor">
+
                 {% form_errors form %}
 
 
@@ -38,30 +45,30 @@
 
                 <div class="two fields ">
                     <div class="field">
-                    <label>Recipe Name</label>
-                    {{ form.name }}
-                    <p class="muted">What do you want to call the recipe</p>
+                        <label>Recipe Name</label>
+                        {{ form.name }}
+                        <p class="muted">What do you want to call the recipe</p>
                     </div>
 
-                                    <div class="field">
-                    <label>Unique Identifier ( uid )</label>
-                    {{ form.uid }}
-                    <p class="muted">Unique identifier, change if needed.</p>
-                </div>
+                    <div class="field">
+                        <label>Unique Identifier ( uid )</label>
+                        {{ form.uid }}
+                        <p class="muted">Unique identifier, change if needed.</p>
+                    </div>
                 </div>
 
                 <div class=" two fields ">
                     <div class="field">
-                    <label>Recipe rank</label>
-                    {{ form.rank }}
-                    <p class="muted">Used to order recipes (optional).</p>
+                        <label>Recipe rank</label>
+                        {{ form.rank }}
+                        <p class="muted">Used to order recipes (optional).</p>
                     </div>
 
-                                    <div class="field">
-                    <label> Image {{ form.image.errors }}</label>
-                    {{ form.image }}
-                    <p class="muted">Optional image for the recipe ( 500px Maximum ).</p>
-                </div>
+                    <div class="field">
+                        <label> Image {{ form.image.errors }}</label>
+                        {{ form.image }}
+                        <p class="muted">Optional image for the recipe ( 500px Maximum ).</p>
+                    </div>
 
                 </div>
 
@@ -116,53 +123,53 @@
                 </div>
 
                 <div class="ui tiny inputcolor modal" id="json_modal">
-                      <div id="json_preview_cont"></div>
+                    <div id="json_preview_cont"></div>
                 </div>
 
             </div>
-
-            <div class="ui raised segment inputcolor">
-
-                {% csrf_token %}
-
-                <div class="field">
-                    <div class="ui header">Build code</div>
-                </div>
-
-                <div class="field">
-                    The code that gets executed when the recipe runs.
-                    <div class="ui top pointing dropdown" id="code_add" style="float: right">
-                        <i class="caret down icon"></i>
-                       <a>Code Builder</a>
-                        {% snippet_list %}
-                    </div>
-
-                </div>
-
-                <div class="field" id="template_field">
-                    {% template_field form.template.value %}
-                </div>
-
-                <div class="field">
-
-                    <button class="ui purple button" data-project_uid={{ project.uid }}
-                            id="template_preview">
-                        <i class="eye icon"></i>Preview Code
-                    </button>
-
-                    <button type="submit" class="ui green button">
-                        <i class="save icon"></i>Submit
-                    </button>
-
-                    <a class="ui right floated button" href="{% url 'recipe_view' recipe.uid %}">
-                        <i class="undo icon"></i> Back
-                    </a>
-                </div>
-                <div class="ui tiny inputcolor modal" id="template_modal">
-                       <div id="template_preview_cont"></div>
-                </div>
-            </div>
-
         </div>
+        <div class="ui raised segment inputcolor">
+
+            {% csrf_token %}
+
+            <div class="field">
+                <div class="ui header">Build code</div>
+            </div>
+
+            <div class="field">
+                The code that gets executed when the recipe runs.
+                <div class="ui top pointing dropdown" id="code_add" style="float: right">
+                    <i class="caret down icon"></i>
+                    <a>Code Builder</a>
+                    {% snippet_list %}
+                </div>
+
+            </div>
+
+            <div class="field" id="template_field">
+                {% template_field form.template.value %}
+            </div>
+
+            <div class="field">
+
+                <button class="ui purple button" data-project_uid={{ project.uid }}
+                        id="template_preview">
+                    <i class="eye icon"></i>Preview Code
+                </button>
+
+                <button type="submit" class="ui green button">
+                    <i class="save icon"></i>Submit
+                </button>
+
+                <a class="ui right floated button" href="{% url 'recipe_view' recipe.uid %}">
+                    <i class="undo icon"></i> Back
+                </a>
+            </div>
+            <div class="ui tiny inputcolor modal" id="template_modal">
+                <div id="template_preview_cont"></div>
+            </div>
+        </div>
+
+
     </form>
 {% endblock %}

--- a/biostar/recipes/templates/recipe_edit.html
+++ b/biostar/recipes/templates/recipe_edit.html
@@ -10,25 +10,21 @@
 {% endblock %}
 
 {% block headtitle %}
-    {% if recipe %}
-        Editing: {{ name }}
-    {% else %}
-        Creating
-    {% endif %}
+
+    Editing: {{ name }}
 {% endblock %}
 
 {% block content %}
 
     <form method="post" class="ui form" action="{{ action_url }}" enctype='multipart/form-data'>
 
-        <div class="narrow">
-            {% if recipe %}
-                <div class="ui raised segment">
-                    {% recipe_details recipe %}
-                </div>
-            {% endif %}
 
             <div class="ui raised segment inputcolor">
+
+        <div class="ui center aligned header">
+            Editing : <a href="{% if recipe %}{{ recipe.url }}{% endif %}"><i class="setting icon"></i>{{ name }}</a>
+        </div>
+
 
                 {% form_errors form %}
 
@@ -127,7 +123,7 @@
                 </div>
 
             </div>
-        </div>
+
         <div class="ui raised segment inputcolor">
 
             {% csrf_token %}

--- a/biostar/recipes/templates/recipe_run.html
+++ b/biostar/recipes/templates/recipe_run.html
@@ -12,7 +12,6 @@
 {% block content %}
     <div style="text-align: -webkit-center;">
     <div class="ui raised segment inputcolor" style="width:70%; text-align: initial">
-
         <div class="ui center aligned header">
             Run : <a href="{% url 'recipe_view' analysis.uid %}"><i class="setting icon"></i>{{ analysis.name }}</a>
         </div>

--- a/biostar/recipes/templates/recipe_view.html
+++ b/biostar/recipes/templates/recipe_view.html
@@ -27,32 +27,8 @@
 
     <div class="ui large vertical segment" id="view">
 
-        <div class="ui divided link items">
-            <div class="item">
-                <div>
-                    <img class="ui tiny rounded fancy image" src="{% img recipe %}">
-                </div>
-                <div class="content ">
-                    <a class="subheader" href="{% url 'recipe_view' recipe.uid %}">
-                        {% if recipe.is_cloned %}
-                            <i class="linkify icon"></i>
-                        {% else %}
-                            <i class="setting icon"></i>
-                        {% endif %}
-                        {{ recipe.name }}
-                    </a>
-                    <div class="meta">
 
-                        {{ recipe.summary|markdown }}
-
-                    </div>
-                    <div class="extra">
-                        {% created_by date=recipe.lastedit_date user=recipe.lastedit_user %}
-                    </div>
-                </div>
-            </div>
-        </div>
-
+                {% recipe_details recipe %}
 
     </div>
 

--- a/biostar/recipes/templates/widgets/access_form.html
+++ b/biostar/recipes/templates/widgets/access_form.html
@@ -23,9 +23,14 @@
                     </div>
                     {{ user.profile.name }}
                 </a>
+                {% if user.profile.trusted %}
+                    <div class="ui right floated green label">
+                        Trusted User
+                    </div>
+                {% endif %}
                 <br>
 
-                    <i class="at icon muted"></i>
+                <i class="at icon muted"></i>
                 <span class="muted" style="margin-left: 14px;">{{ user.profile.uid }}</span>
 
             </div>

--- a/biostar/recipes/templates/widgets/list_view.html
+++ b/biostar/recipes/templates/widgets/list_view.html
@@ -18,7 +18,7 @@
                             <i class="database icon"></i>{{ project.name }}
                         </a>
                         {% if user.is_authenticated %}
-                            <div class="ui right ribbon label listing">
+                            <div class="ui right ribbon label listing" >
                                 {% get_access_label project user %}
                             </div>
                         {% endif %}

--- a/biostar/recipes/templates/widgets/recipe_details.html
+++ b/biostar/recipes/templates/widgets/recipe_details.html
@@ -1,0 +1,30 @@
+{% load staticfiles %}
+{% load engine_tags %}
+
+{% if recipe %}
+    <div class="ui divided link items">
+
+        <div class="item">
+            <div>
+                <img class="ui tiny rounded fancy image" src="{% img recipe %}">
+            </div>
+            <div class="content ">
+                <a class="subheader" href="{% url 'recipe_view' recipe.uid %}">
+                    {% if recipe.is_cloned %}
+                        <i class="linkify icon"></i>
+                    {% else %}
+                        <i class="setting icon"></i>
+                    {% endif %}
+                    {{ recipe.name }}
+                </a>
+                <div class="meta">
+                    {{ recipe.summary|markdown }}
+
+                </div>
+                <div class="extra">
+                    {% created_by date=recipe.lastedit_date user=recipe.lastedit_user %}
+                </div>
+            </div>
+        </div>
+    </div>
+{% endif %}

--- a/biostar/recipes/templates/widgets/recipe_form.html
+++ b/biostar/recipes/templates/widgets/recipe_form.html
@@ -23,7 +23,7 @@
         {{ field }}
         {% endif %}
 
-        <div class="muted">{{ field.help_text | safe }}</div>
+        <div class="muted">{{ field.help_text }}</div>
     </div>
 
 {% endfor %}

--- a/biostar/recipes/templates/widgets/recipe_form.html
+++ b/biostar/recipes/templates/widgets/recipe_form.html
@@ -19,7 +19,7 @@
             {{ field }} <label for="{{ field.id_for_label }}">{{ field.label }}</label>
         </div>
         {% else %}
-        {{ field.label_tag }}
+        {{ field.label_tag|safe }}
         {{ field }}
         {% endif %}
 

--- a/biostar/recipes/templatetags/engine_tags.py
+++ b/biostar/recipes/templatetags/engine_tags.py
@@ -372,9 +372,6 @@ def show_messages(messages):
     return dict(messages=messages)
 
 
-def is_data():
-    return
-
 
 @register.inclusion_tag('widgets/project_title.html', takes_context=True)
 def project_title(context, project):
@@ -385,11 +382,11 @@ def project_title(context, project):
 
 
 @register.inclusion_tag('widgets/recipe_form.html')
-def recipe_form(form, json_text=None):
+def recipe_form(form):
     """
     Renders a recipe form.
     """
-    return dict(form=form, json_text=json_text)
+    return dict(form=form)
 
 
 @register.inclusion_tag('widgets/interface_options.html')

--- a/biostar/recipes/templatetags/engine_tags.py
+++ b/biostar/recipes/templatetags/engine_tags.py
@@ -372,6 +372,10 @@ def show_messages(messages):
     return dict(messages=messages)
 
 
+def is_data():
+    return
+
+
 @register.inclusion_tag('widgets/project_title.html', takes_context=True)
 def project_title(context, project):
     """
@@ -381,16 +385,21 @@ def project_title(context, project):
 
 
 @register.inclusion_tag('widgets/recipe_form.html')
-def recipe_form(form):
+def recipe_form(form, json_text=None):
     """
     Renders a recipe form.
     """
-    return dict(form=form)
+    return dict(form=form, json_text=json_text)
 
 
 @register.inclusion_tag('widgets/interface_options.html')
 def interface_options():
     return dict()
+
+
+@register.inclusion_tag('widgets/recipe_details.html')
+def recipe_details(recipe):
+    return dict(recipe=recipe)
 
 
 @register.simple_tag

--- a/biostar/recipes/test/test_project.py
+++ b/biostar/recipes/test/test_project.py
@@ -116,7 +116,7 @@ class ProjectViewTest(TestCase):
         user_forms = forms.access_forms(users, project=self.project, request=request)
 
         # Error generating users access forms ( forms.access_forms).
-        self.assertTrue(len(users) - 1 == len(user_forms))
+        self.assertTrue(len(users) == len(user_forms))
 
     def process_response(self, response, data, save=False):
         "Check the response on POST request is redirected"

--- a/biostar/recipes/views.py
+++ b/biostar/recipes/views.py
@@ -990,7 +990,7 @@ def import_files(request, path=''):
     """
     user = request.user
 
-    if user.profile.trusted:
+    if not user.profile.trusted:
         messages.error(request, 'Only trusted users may views this page.')
         return redirect(reverse('project_list'))
 

--- a/biostar/recipes/views.py
+++ b/biostar/recipes/views.py
@@ -791,7 +791,8 @@ def recipe_create(request, uid):
     project = Project.objects.filter(uid=uid).first()
 
     # Prepare the form
-    initial = dict(name="Recipe Name", uid=f'recipe-{util.get_uuid(5)}')
+    name = "Recipe Name"
+    initial = dict(name=name, uid=f'recipe-{util.get_uuid(5)}')
     form = forms.RecipeForm(user=request.user, initial=initial, project=project)
 
     if request.method == "POST":
@@ -810,7 +811,8 @@ def recipe_create(request, uid):
             return redirect(reverse("recipe_view", kwargs=dict(uid=recipe.uid)))
 
     action_url = reverse('recipe_create', kwargs=dict(uid=uid))
-    context = dict(project=project, form=form, action_url=action_url, activate='Create Recipe')
+    context = dict(project=project, form=form, action_url=action_url,
+                   activate='Create Recipe', name=name)
     counts = get_counts(project)
     context.update(counts)
     return render(request, 'recipe_edit.html', context)


### PR DESCRIPTION
- show type in recipe data label.
- user status shows in manage access view.
- all user, including owner and current user, with access are displayed in manage access view.
- recipes with clones can not be deleted.
- added `root` field to recipe admin page.
- all recipe edit forms increased in width. 
- trusted users get can see import tab.
-  recipe name shown on edit ( similar to recipe run ).
- trusted users and admin get a higher upload limit.