### PR TITLE
fixes in makefile 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,29 @@
 # Database JSON dump files.
-export SAVE_FILE=export/backup/db.last.json
+SAVE_FILE=export/backup/db.last.json
 
 # Backup file.
-export BACKUP_FILE=export/backup/db.`date +'%Y-%m-%d-%H%M'`.json
+BACKUP_FILE=export/backup/db.`date +'%Y-%m-%d-%H%M'`.json
 
 # Default settings module.
-export DJANGO_SETTINGS_MODULE := biostar.server.settings
+DJANGO_SETTINGS_MODULE := biostar.server.settings
 
 # Default app.
-export DJANGO_APP :=
+DJANGO_APP :=
 
 # Database name
-export DATABASE_NAME := export/db/database.db
+DATABASE_NAME := database.db
 
 # Command used to load initial data
-export LOAD_COMMAND := project
+LOAD_COMMAND := project
 
 # Search index name
-export INDEX_NAME := index
+INDEX_NAME := index
 
 # Search index directory
-export INDEX_DIR := search
+INDEX_DIR := search
 
 # Recipes database to copy
-export COPY_DATABASE := recipes.db
+COPY_DATABASE := recipes.db
 
 all: recipes serve
 
@@ -93,7 +93,7 @@ reset: echo
 	# Delete the database, logs and CACHE files.
 	# Keep media and spooler.
 	rm -rf export/logs/*.log
-	rm -f ${DATABASE_NAME}
+	rm -f export/db/${DATABASE_NAME}
 	rm -rf export/static/CACHE
 	rm -rf *.egg
 	rm -rf *.egg-info

--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,29 @@
 # Database JSON dump files.
-SAVE_FILE=export/backup/db.last.json
+export SAVE_FILE=export/backup/db.last.json
 
 # Backup file.
-BACKUP_FILE=export/backup/db.`date +'%Y-%m-%d-%H%M'`.json
+export BACKUP_FILE=export/backup/db.`date +'%Y-%m-%d-%H%M'`.json
 
 # Default settings module.
-DJANGO_SETTINGS_MODULE := biostar.server.settings
+export DJANGO_SETTINGS_MODULE := biostar.server.settings
 
 # Default app.
-DJANGO_APP :=
+export DJANGO_APP :=
 
 # Database name
-DATABASE_NAME := database.db
+export DATABASE_NAME := database.db
 
 # Command used to load initial data
-LOAD_COMMAND := project
+export LOAD_COMMAND := project
 
 # Search index name
-INDEX_NAME := index
+export INDEX_NAME := index
 
 # Search index directory
-INDEX_DIR := search
+export INDEX_DIR := search
 
 # Recipes database to copy
-COPY_DATABASE := recipes.db
+export COPY_DATABASE := recipes.db
 
 all: recipes serve
 
@@ -93,6 +93,7 @@ reset: echo
 	# Delete the database, logs and CACHE files.
 	# Keep media and spooler.
 	rm -rf export/logs/*.log
+	# Database is always found in export/db/
 	rm -f export/db/${DATABASE_NAME}
 	rm -rf export/static/CACHE
 	rm -rf *.egg

--- a/Makefile
+++ b/Makefile
@@ -1,36 +1,35 @@
 # Database JSON dump files.
-SAVE_FILE=export/backup/db.last.json
+export SAVE_FILE=export/backup/db.last.json
 
 # Backup file.
-BACKUP_FILE=export/backup/db.`date +'%Y-%m-%d-%H%M'`.json
+export BACKUP_FILE=export/backup/db.`date +'%Y-%m-%d-%H%M'`.json
 
 # Default settings module.
-DJANGO_SETTINGS_MODULE := biostar.server.settings
+export DJANGO_SETTINGS_MODULE := biostar.server.settings
 
 # Default app.
-DJANGO_APP :=
+export DJANGO_APP :=
 
 # Database name
-DATABASE_NAME := export/db/database.db
+export DATABASE_NAME := export/db/database.db
 
 # Command used to load initial data
-LOAD_COMMAND := project
+export LOAD_COMMAND := project
 
 # Search index name
-INDEX_NAME := index
+export INDEX_NAME := index
 
 # Search index directory
-INDEX_DIR := search
+export INDEX_DIR := search
 
 # Recipes database to copy
-COPY_DATABASE := recipes.db
+export COPY_DATABASE := recipes.db
 
 all: recipes serve
 
 accounts:
 	$(eval DJANGO_SETTINGS_MODULE := biostar.accounts.settings)
 	$(eval DJANGO_APP := biostar.accounts)
-
 
 emailer:
 	$(eval DJANGO_SETTINGS_MODULE := biostar.emailer.settings)
@@ -59,7 +58,6 @@ serve: init
 init: echo
 	python manage.py collectstatic --noinput -v 0  --settings ${DJANGO_SETTINGS_MODULE}
 	python manage.py migrate -v 0  --settings ${DJANGO_SETTINGS_MODULE}
-
 
 test:
 	@echo DJANGO_SETTINGS_MODULE=${DJANGO_SETTINGS_MODULE}
@@ -91,11 +89,11 @@ copy: reset
 	@echo COPY_DATABASE=${COPY_DATABASE}
 	python manage.py copy --db ${COPY_DATABASE} --settings ${DJANGO_SETTINGS_MODULE}
 
-reset:
+reset: echo
 	# Delete the database, logs and CACHE files.
 	# Keep media and spooler.
 	rm -rf export/logs/*.log
-	rm -f export/db/${DATABASE_NAME}
+	rm -f ${DATABASE_NAME}
 	rm -rf export/static/CACHE
 	rm -rf *.egg
 	rm -rf *.egg-info

--- a/biostar/server/urls.py
+++ b/biostar/server/urls.py
@@ -1,7 +1,8 @@
 
 from django.conf import settings
 from django.urls import path, include
-
+import debug_toolbar
+from django.conf.urls.static import static
 from biostar.forum.urls import forum_patterns
 from biostar.recipes.urls import recipes_patterns
 import biostar.accounts.urls as accounts_urls
@@ -23,3 +24,7 @@ urlpatterns = [
     path(r'accounts/', include(accounts_urls)),
 
 ]
+
+if settings.DEBUG:
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT, show_indexes=True)
+    urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT, show_indexes=True)

--- a/biostar/settings.py
+++ b/biostar/settings.py
@@ -136,7 +136,10 @@ AUTH_PASSWORD_VALIDATORS = [
 DATABASE_DIR = os.path.join(BASE_DIR, 'export', 'db')
 os.makedirs(DATABASE_DIR, exist_ok=True)
 
-DATABASE_NAME = os.path.join(DATABASE_DIR, os.environ.setdefault("DATABASE_NAME", "database.db"))
+DATABASE_NAME = os.environ.setdefault("DATABASE_NAME", "database.db")
+# Ensure database is inside database directory.
+DATABASE_NAME = os.path.join(DATABASE_DIR, DATABASE_NAME)
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',

--- a/biostar/settings.py
+++ b/biostar/settings.py
@@ -133,7 +133,10 @@ AUTH_PASSWORD_VALIDATORS = [
 
 # Database settings.
 # https://docs.djangoproject.com/en/1.11/ref/settings/#databases
-DATABASE_NAME = os.environ.setdefault("DATABASE_NAME", "database.db")
+DATABASE_DIR = os.path.join(BASE_DIR, 'export', 'db')
+os.makedirs(DATABASE_DIR, exist_ok=True)
+
+DATABASE_NAME = os.path.join(DATABASE_DIR, os.environ.setdefault("DATABASE_NAME", "database.db"))
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',


### PR DESCRIPTION
-  Environment variables correctly set in makefile.

DATABASE_NAME always created in export/db/: 
Ensures `reset` always deletes inside of export/db/ and the dangerous action `rm -rf  ${DATABASE_NAME}` is replaced with `rm -rf  export/db/${DATABASE_NAME}`. 