### PR TITLE
fix in page dragging when clicking recipe; content tightened up on wider screens

### DIFF
--- a/biostar/recipes/static/engine.css
+++ b/biostar/recipes/static/engine.css
@@ -25,7 +25,7 @@ body {
     background-color: var(--recipe-search-color) !important;
     height: 35px ;
     width: 254px ;
-    padding: 9px ;
+    padding: 9px !important;
 }
 
 .ui.page-bar.segment {

--- a/biostar/recipes/static/engine.css
+++ b/biostar/recipes/static/engine.css
@@ -68,10 +68,6 @@ body {
     width: 100%;
 }
 
-#code, #interface, #edit{
-    display: none;
-}
-
 #top .header{
     //margin-top: 0px;
 }

--- a/biostar/recipes/static/engine.css
+++ b/biostar/recipes/static/engine.css
@@ -261,7 +261,6 @@ pre.toml_code {
 
 .top-title.header{
     height: 2.5em;
-    margin: 0;
 }
 
 .top-title.header .listing{

--- a/biostar/recipes/static/engine.css
+++ b/biostar/recipes/static/engine.css
@@ -4,7 +4,7 @@
     --code-bg-color: #f9f9f9;
     --job-completed: #21ba45;
     --job-spooled: #6435c9;
-    --job-erorr: #db2828;
+    --job-error: #db2828;
     --job-running: #f2711c;
     --job-queued: #00b5ad;
 
@@ -319,17 +319,17 @@ pre.toml_code {
 
 
 .errored {
-    border-color: var(--job-erorr) !important;
+    border-color: var(--job-error) !important;
 }
 
 .errored.label {
-    border-bottom: 1px solid var(--job-erorr) !important;
-    background-color: var(--job-erorr) !important;
+    border-bottom: 1px solid var(--job-error) !important;
+    background-color: var(--job-error) !important;
     color: white;
 }
 
 .errored.item {
-    color:  var(--job-erorr) !important;
+    color:  var(--job-error) !important;
 }
 
 .running {

--- a/biostar/recipes/static/engine.css
+++ b/biostar/recipes/static/engine.css
@@ -68,6 +68,10 @@ body {
     width: 100%;
 }
 
+#code, #interface, #edit{
+    display: none;
+}
+
 #top .header{
     //margin-top: 0px;
 }

--- a/biostar/recipes/static/engine.css
+++ b/biostar/recipes/static/engine.css
@@ -761,6 +761,14 @@ blockquote {
 
 }
 
+@media all and (min-width: 1400px) {
+
+    #top > .segment{
+        padding-left: 10%;
+        padding-right: 10%;
+    }
+}
+
 @media all and (max-width: 500px) {
 
 

--- a/biostar/recipes/static/engine.css
+++ b/biostar/recipes/static/engine.css
@@ -261,6 +261,7 @@ pre.toml_code {
 
 .top-title.header{
     height: 2.5em;
+    margin: 0;
 }
 
 .top-title.header .listing{

--- a/biostar/recipes/static/recipes.js
+++ b/biostar/recipes/static/recipes.js
@@ -273,12 +273,17 @@ function get_id() {
 $(document).ready(function () {
 
     // Select default open item.
-    var open_id = window.location.hash || "#info";
+    var open_id = window.location.hash;
 
-    // Initial toggle has no animation.
-    toggle_panels(open_id, 1);
+    // Update information in dynamic panels when id is provided.
+    if (open_id){
+        // Initial toggle has no animation.
+        toggle_panels(open_id, 1);
+    }else{
+        // Show the info panel by default when a hash is not set.
+        $(".collapse:not(#info)").hide();
+    }
 
-    // Update information in dynamic panels.
     update_panels();
 
     // Bind the events.

--- a/biostar/recipes/templates/base_template.html
+++ b/biostar/recipes/templates/base_template.html
@@ -56,7 +56,7 @@
         {% menubar request=request %}
     {% endblock %}
 
-    <div class="ui bottom attached segment">
+    <div class="ui bottom attached very padded segment">
         <div id="search-results"></div>
         <div class="ui center aligned top-title header" >
          <span>

--- a/biostar/recipes/templates/base_template.html
+++ b/biostar/recipes/templates/base_template.html
@@ -56,7 +56,7 @@
         {% menubar request=request %}
     {% endblock %}
 
-    <div class="ui bottom attached very padded segment">
+    <div class="ui bottom attached padded segment">
         <div id="search-results"></div>
         <div class="ui center aligned top-title header" >
          <span>

--- a/biostar/recipes/templates/parts/recipe_code.html
+++ b/biostar/recipes/templates/parts/recipe_code.html
@@ -2,7 +2,6 @@
 
 <form method="post" class="ui form" action="#">
 
-
     <div class="field" id="template_field">
         <textarea class="code" rows="80" cols="55" name="template" id="code_editor">{{ form.template.value }}</textarea>
     </div>

--- a/biostar/recipes/templates/recipe_view.html
+++ b/biostar/recipes/templates/recipe_view.html
@@ -86,8 +86,7 @@
 
             {# Info panel. Loads dynamically. #}
             <div class="ui basic large segment collapse" id="info">
-
-                {% include "parts/recipe_info.html" %}
+                {#% include "parts/recipe_info.html" %#}
             </div>
 
             {# Code panel. #}

--- a/biostar/recipes/templates/recipe_view.html
+++ b/biostar/recipes/templates/recipe_view.html
@@ -86,7 +86,7 @@
 
             {# Info panel. Loads dynamically. #}
             <div class="ui basic large segment collapse" id="info">
-                {#% include "parts/recipe_info.html" %#}
+                {% include "parts/recipe_info.html" %}
             </div>
 
             {# Code panel. #}


### PR DESCRIPTION
- fix page dragging when clicking recipes, recipe info loaded by default.
- content on wide screens ( 1400px or above ) given side padding to narrow the field of vision. 
