### PR TITLE
fix issue with recipe count on project creation 

### DIFF
--- a/biostar/forum/signals.py
+++ b/biostar/forum/signals.py
@@ -36,7 +36,7 @@ def ban_user(sender, instance, created, **kwargs):
         #print(Post.objects.filter(author=instance.user).thread_users)
         Post.objects.filter(author=instance.user).delete()
         #print(Post.objects.filter(author=instance))
-        # Remove all 'lastedit user' flags
+        # Remove all 'lastedit user' flags for this user.
         # posts = Post.objects.filter(lastedit_user=instance.user)
         # for post in posts:
         #     Post.objects.filter(id=post.id).update(lastedit_user=post.author)
@@ -50,6 +50,10 @@ def ban_user(sender, instance, created, **kwargs):
 
         # Delete all messages
         Message.objects.filter(Q(sender=instance.user) | Q(recipient=instance.user)).delete()
+
+    # Label all posts by a spammer as 'spam'
+    if instance.is_spammer:
+        Post.objects.filter(author=instance.user).update(spam=Post.SPAM)
 
 
 @receiver(post_save, sender=Post)

--- a/biostar/recipes/models.py
+++ b/biostar/recipes/models.py
@@ -174,12 +174,15 @@ class Project(models.Model):
         """
         Set the data, recipe, and job count for this project
         """
-        data_count = self.data_set.filter(deleted=False).count()
-        recipes_count = self.analysis_set.filter(project=self, deleted=False).count()
-        job_count = self.job_set.filter(deleted=False).count()
 
-        Project.objects.filter(id=self.id).update(data_count=data_count, recipes_count=recipes_count,
-                                                  jobs_count=job_count)
+        # Set the counts on current instance and also update in database.
+        self.recipes_count = self.analysis_set.filter(project=self, deleted=False).count()
+        self.data_count = self.data_set.filter(deleted=False).count()
+        self.job_count = self.job_set.filter(deleted=False).count()
+
+        Project.objects.filter(id=self.id).update(data_count=self.data_count,
+                                                  recipes_count=self.recipes_count,
+                                                  jobs_count=self.job_count)
 
     @property
     def is_public(self):

--- a/biostar/recipes/signals.py
+++ b/biostar/recipes/signals.py
@@ -102,7 +102,8 @@ def finalize_project(sender, instance, created, raw, update_fields, **kwargs):
 
         # Update project fields.
         Project.objects.filter(id=instance.id).update(uid=instance.uid, dir=instance.dir, rank=instance.rank)
-        # Create a starter recipe if none exist
+
+        # Create a starter recipe if none exist.
         if not instance.analysis_set.exists():
             initial_recipe(project=instance)
 


### PR DESCRIPTION
- corrected off-by-one-error in recipe count on the project creation.
- all posts by spammers now labeled as spam.
