### PR TITLE
"export VAR=value" is bash syntax ( not sh-portable )

### DIFF
--- a/conf/defaults.env
+++ b/conf/defaults.env
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Path to the biostar code repository.
 export BIOSTAR_HOME=`pwd`


### PR DESCRIPTION
The subject says it. New "master" branch probably moves away from shell scripts in favor of an ansible-based install, but for those who want to install the "oldstable" version, this `#!/bin/sh` could be a little misleading.

( Basically if sourced though any default system `/bin/sh` replacement, export may not work properly, and therefore starting wsgi app may fail with an unhelpful error _"'DJANGO_SETTINGS_MODULE' environment variable must be set"_ )
