### PR TITLE
ALLOWED_TAGS missing commas between h2 and h3 tag.

### DIFF
--- a/biostar/forum/markdown.py
+++ b/biostar/forum/markdown.py
@@ -75,7 +75,7 @@ ALLOWED_ATTRIBUTES = {
     'table': ['border', 'cellpadding', 'cellspacing'],
 }
 
-ALLOWED_TAGS = ['p', 'div', 'br', 'code', 'pre', 'h1', 'h2' 'h3' 'h4', 'hr', 'span', 's',
+ALLOWED_TAGS = ['p', 'div', 'br', 'code', 'pre', 'h1', 'h2', 'h3', 'h4', 'hr', 'span', 's',
                 'sub', 'sup', 'b', 'i', 'img', 'strong', 'strike', 'em', 'underline',
                 'super', 'table', 'thead', 'tr', 'th', 'td', 'tbody']
 


### PR DESCRIPTION
ALLOWED_TAGS missing commas between h2 and h3 tag causing a parsing error in those tags.