### PR TITLE
Fix bug with non-field related errors

### DIFF
--- a/biostar/forum/templatetags/forum_tags.py
+++ b/biostar/forum/templatetags/forum_tags.py
@@ -368,7 +368,7 @@ def form_errors(form, wmd_prefix='', override_content=False):
     """
 
     try:
-        errorlist = [('', message) for message in form.non_field_errors()]
+        errorlist = [('', message, '') for message in form.non_field_errors()]
         for field in form:
             for error in field.errors:
                 # wmd_prefix is required when dealing with 'content' field.


### PR DESCRIPTION
Because `forum/templates/forms/forum_errors.html` tries to unpack 3 values any non-field error of the form `raise ValidationError("<message>")` will throw an error saying "Not enough values to unpack."

Adding an extra empty string fixes this.