### PR TITLE
Simplify Post Type generation

### DIFF
--- a/biostar/forum/models.py
+++ b/biostar/forum/models.py
@@ -86,15 +86,17 @@ class Post(models.Model):
                       (DELETED, "Deleted")]
 
     # Question types. Answers should be listed before comments.
-    QUESTION, ANSWER, JOB, FORUM, PAGE, BLOG, COMMENT, DATA, TUTORIAL, BOARD, TOOL, NEWS = range(12)
+    question_types = [
+        'question', 'answer', 'job', 'forum', 'page', 'blog', 'comment', 'data',
+        'tutorial', 'board', 'tool', 'news'
+    ]
+    # Raise the post types to class-level enums keyed as upper()
+    for i, q in enumerate(question_types):
+        local()[q.upper()] = i
 
     # Valid post types.
-    TYPE_CHOICES = [
-        (QUESTION, "Question"), (ANSWER, "Answer"), (COMMENT, "Comment"),
-        (JOB, "Job"), (FORUM, "Forum"), (TUTORIAL, "Tutorial"),
-        (DATA, "Data"), (PAGE, "Page"), (TOOL, "Tool"), (NEWS, "News"),
-        (BLOG, "Blog"), (BOARD, "Bulletin Board")
-    ]
+    TYPE_CHOICES = [(i, q.title()) for i, q in enumerate(question_types)]
+
     TOP_LEVEL = {QUESTION, JOB, FORUM, BLOG, TUTORIAL, TOOL, NEWS}
 
     # Possible spam states.


### PR DESCRIPTION
This is just a suggestion to clean up some of this enum stuff on the Post model. As I've been working with modifying the post types I've been finding some of it to be rather spread out and difficult to modify. Doing this means I only have to modify one array to add or modify a post type. And this can mostly be done for the several enum sets you have here, like spam states and post statuses. I'm even considering moving the mapper dictionary from views to posts.

Anyway, I don't know if this is an unwelcome suggestion or not, but I've forked your repo and have been working on it a lot and I just thought you might be interested in this. I plan on trying to contribute some more of my changes back upstream, not sure if you're interested in that or not.