### PR TITLE
Fix __str__ bug on emailer.models.Subscription

### DIFF
--- a/biostar/emailer/models.py
+++ b/biostar/emailer/models.py
@@ -63,7 +63,7 @@ class Subscription(models.Model):
     group = models.ForeignKey(EmailGroup, on_delete=models.CASCADE)
 
     def __str__(self):
-        return f"{self.address.name} | {self.list.name}"
+        return f"{self.address.name} | {self.group.name}"
 
     def save(self, *args, **kwargs):
         self.uid = self.uid or get_uuid(16)


### PR DESCRIPTION
The attribute "list" is not on the objects, so the emailer subscriptions tab in the admin section consistently fails.

One question, though: what is this emailer section for? You generate 2000 some random fake email addresses and subscriptions and groups and I'm not really sure as to why. Is it for testing? Plus, there's the separate mailer section. Not really sure what the difference between mailer and emailer is.

Thanks!