### PR TITLE
Fix mass_html_email bug

### DIFF
--- a/biostar/emailer/sender.py
+++ b/biostar/emailer/sender.py
@@ -131,13 +131,13 @@ def send_mass_html_mail(subject, message, message_html, from_email, recipient_li
         msg = EmailMultiAlternatives(subject=subject,
                                      body=message,
                                      from_email=from_email,
-                                     to=rec,
-                                     connection=connection).attach_alternative(message_html,
-                                                                         "text/html")
+                                     to=[rec],
+                                     connection=connection)
+        msg.attach_alternative(message_html, "text/html")
         return msg
 
     # Format mass mail
-    messages = map(make_email, recipient_list)
+    messages = list(map(make_email, recipient_list))
 
     return connection.send_messages(messages)
 


### PR DESCRIPTION
I saw that all the emails were text-based and I wanted to get html, so I short-circuited the `if len(html) > 10` switch in the EmailTemplate.send_mass to test it and found a couple bugs.

1. `to` in `EmailMultiAlternatives` needs to be a list or tuple
2. `attach_alternative` doesn't return anything, so the result was it was passing an array of None's to send_messages
3. It complained about having a map instead of a list.

With these 3 changes I could get mass html emails through digest/mailing list.