### PR TITLE
Natay/fix from email breaking with special chars

### DIFF
--- a/biostar/emailer/sender.py
+++ b/biostar/emailer/sender.py
@@ -55,15 +55,19 @@ def clean_address(email):
     """
     Strip special chars from the ``name`` portion of a given mail.
     """
-    split = email.split()
-    parsed_email = split[-1]
-    name = ' '.join(split[:-1])
-    # Remove punctuation from name
-    table = str.maketrans('', '', string.punctuation)
-    name = name.translate(table)
-    # patch name and email back together
-    from_email = f'{name} {parsed_email}'
-    return from_email
+    try:
+        split = email.split()
+        parsed_email = split[-1]
+        name = ' '.join(split[:-1])
+        # Remove punctuation from name
+        table = str.maketrans('', '', string.punctuation)
+        name = name.translate(table)
+        # patch name and email back together
+        email = f'{name} {parsed_email}'
+    except Exception as exc:
+        logger.error(f"Error cleaning email address: {email}, {exc}")
+
+    return email
 
 
 class EmailTemplate(object):

--- a/biostar/emailer/sender.py
+++ b/biostar/emailer/sender.py
@@ -1,7 +1,6 @@
 import logging
 import re
 import textwrap
-import string
 
 from django.core.mail import EmailMultiAlternatives
 from django.core.mail import send_mail, send_mass_mail, get_connection

--- a/biostar/emailer/sender.py
+++ b/biostar/emailer/sender.py
@@ -51,25 +51,6 @@ def first_line(text):
     return first
 
 
-def clean_address(email):
-    """
-    Strip special chars from the ``name`` portion of a given mail.
-    """
-    try:
-        split = email.split()
-        parsed_email = split[-1]
-        name = ' '.join(split[:-1])
-        # Remove punctuation from name
-        table = str.maketrans('', '', string.punctuation)
-        name = name.translate(table)
-        # patch name and email back together
-        email = f'{name} {parsed_email}'
-    except Exception as exc:
-        logger.error(f"Error cleaning email address: {email}, {exc}")
-
-    return email
-
-
 class EmailTemplate(object):
     """
     Generates a subject, text and html based email from a single template.
@@ -92,7 +73,6 @@ class EmailTemplate(object):
     def send(self, context, from_email, recipient_list):
 
         recipients = ", ".join(recipient_list)
-        from_email = clean_address(from_email)
 
         # Skip sending emails during data migration
         if settings.DATA_MIGRATION:
@@ -125,7 +105,6 @@ class EmailTemplate(object):
         Send mass individual mail to list of recipients
         """
         subject, text, html = self.render(context)
-        from_email = clean_address(from_email)
 
         # Text may be indented in template.
         text = textwrap.dedent(text)

--- a/biostar/emailer/tasks.py
+++ b/biostar/emailer/tasks.py
@@ -1,11 +1,26 @@
 import logging
 import os
+import string
 
 from django.conf import settings
 
 from biostar.emailer import sender
 
 logger = logging.getLogger("engine")
+
+
+def clean_name(name):
+    """
+    Strip special chars from the ``name`` portion of a given mail.
+    """
+    try:
+        # Remove punctuation from name
+        table = str.maketrans('', '', string.punctuation)
+        name = name.translate(table)
+    except Exception as exc:
+        logger.error(f"Error cleaning name: {name}, {exc}")
+
+    return name
 
 
 def send_all():
@@ -41,6 +56,7 @@ def send_email(template_name, recipient_list, extra_context={}, name="", from_em
 
     # Final sender email
     from_email = from_email or settings.DEFAULT_FROM_EMAIL
+    name = clean_name(name)
     from_email = patt % (name, from_email)
 
     # Test the templates exists


### PR DESCRIPTION
Address following error that crop up ( a lot more common on bioconductor ) by cleaning the from_email of any punctuations. 
``` send_email error: Invalid address; only NAME could be parsed from "NAME, Ph.D. <[mailer@biostars.org]>" ```
