### PR TITLE
Suspend new users for spamming URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ __pycache__/
 *secrets*.py
 .pyc
 *.so
+*.log
 

--- a/biostar/forum/forms.py
+++ b/biostar/forum/forms.py
@@ -238,7 +238,7 @@ def spam_check(value, target, user):
         r'^https?://[^\s/$.?#].[^\s]*$',
         re.IGNORECASE
     )
-    url_only = bool(URL_PATTERN.fullmatch(value))
+    url_only = bool(URL_PATTERN.fullmatch(content))
     if url_only:
         suspend_user(user)
 

--- a/biostar/forum/forms.py
+++ b/biostar/forum/forms.py
@@ -232,6 +232,15 @@ def spam_check(value, target, user):
         patt = r'%s' % patt
         if re.search(patt, content, flags=re.IGNORECASE):
             suspend_user(user)
+    
+    # ban user if content is URL only
+    URL_PATTERN = re.compile(
+        r'^https?://[^\s/$.?#].[^\s]*$',
+        re.IGNORECASE
+    )
+    url_only = bool(URL_PATTERN.fullmatch(value))
+    if url_only:
+        suspend_user(user)
 
 from biostar.utils import helpers
 


### PR DESCRIPTION
This filter reduces the influx of spam posts that contain only URLs.